### PR TITLE
[Topics] Fix ComsumeChannel coordination. Fixes #3

### DIFF
--- a/Marille/Message.cs
+++ b/Marille/Message.cs
@@ -1,0 +1,24 @@
+namespace Marille;
+
+internal enum MessageType {
+	Ack,
+	Data
+}
+internal struct Message<T> {
+	public Guid Id { get; }
+	public MessageType Type { get; }
+	public T? Payload { get; }
+
+	public Message (MessageType type)
+	{
+		Id = Guid.NewGuid();
+		Type = type;
+		Payload = default;
+	}
+	public Message (MessageType type, T payload)
+	{
+		Id = Guid.NewGuid();
+		Type = type;
+		Payload = payload;
+	}
+}

--- a/Marille/Topic.cs
+++ b/Marille/Topic.cs
@@ -14,20 +14,21 @@ internal class Topic (string name) {
 		channel = null;
 		if (!channels.TryGetValue (type, out var obj)) 
 			return false;
-		channel = new (obj.Configuration, (obj.Channel as Channel<T>)!);
+		channel = new (obj.Configuration, (obj.Channel as Channel<Message<T>>)!);
 		return true;
 	}
 
-	public Channel<T> CreateChannel<T> (TopicConfiguration configuration)
+	public Channel<Message<T>> CreateChannel<T> (TopicConfiguration configuration)
 	{
 		Type type = typeof (T);
 		if (!channels.TryGetValue (type, out var obj)) {
 			var ch = (configuration.Capacity is null) ? 
-				Channel.CreateUnbounded<T> () : Channel.CreateBounded<T> (configuration.Capacity.Value);
-			channels [type] = new (configuration, ch);
+				Channel.CreateUnbounded<Message<T>> () : Channel.CreateBounded<Message<T>> (configuration.Capacity.Value);
+			obj = new (configuration, ch);
+			channels[type] = obj; 
 		}
 
-		return (obj.Channel as Channel<T>)!;
+		return (obj.Channel as Channel<Message<T>>)!;
 	}
 
 	public void CloseChannel<T> ()

--- a/Marille/TopicInfo.cs
+++ b/Marille/TopicInfo.cs
@@ -2,4 +2,4 @@ using System.Threading.Channels;
 
 namespace Marille;
 
-internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<T> Channel);
+internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel);


### PR DESCRIPTION
The tests were not flacky, the code was. We had a few issues because I did not pay attention on how we consume the messages and how we can ensure that we never drop messages:

\# Bugs

1. We were consuming messages withouth workers: dropped messages
2. We were not ensuring that the Create method would return once we started consuming.

To fix the above we had to introduce to changes:

1. If we have no workers, we do not consume messages and let the channel buffer.
2. To be able to coordinate the Consume method and the Create method we added a TaskCompletionSource that will only be set when we have data to consume.
3. If we start with an empty channel, send a Ack message to let the Consume method be ready and the TCS be set.

We have added a struct that wraps the messages default types, this will give use more flexibility later to allow message retries.