### PR TITLE
[API] Do not allow to create or register more than one worker on 1:1 topics.

### DIFF
--- a/Marille.Tests/FastWorker.cs
+++ b/Marille.Tests/FastWorker.cs
@@ -1,0 +1,19 @@
+namespace Marille.Tests;
+
+public struct WorkQueuesEvent (string Id);
+
+public record WorkDoneEvent (string WorkerId);
+
+public class FastWorker : IWorker<WorkQueuesEvent> {
+	public string Id { get; set; } = string.Empty;
+	public TaskCompletionSource<bool> Completion { get; private set; }
+
+	public FastWorker (string id, TaskCompletionSource<bool> tcs)
+	{
+		Id = id;
+		Completion = tcs;
+	}
+
+	public Task ConsumeAsync (WorkQueuesEvent message, CancellationToken cancellationToken = default)
+		=> Task.FromResult (Completion.TrySetResult(true));
+}

--- a/Marille.Tests/RegistrationTests.cs
+++ b/Marille.Tests/RegistrationTests.cs
@@ -1,3 +1,73 @@
 namespace Marille.Tests;
 
-public class RegistrationTests { }
+public class RegistrationTests {
+
+	Hub _hub;
+
+	public RegistrationTests ()
+	{
+		_hub = new ();
+	} 
+
+	[Fact]
+	public async Task SingleOneToOneCreation ()
+	{
+		var topic = nameof (SingleOneToOneCreation); 
+		var tcs = new TaskCompletionSource<bool> ();
+		var worker = new FastWorker ("myWorkerID", tcs);
+		var workers = new [] { worker };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		Assert.True (await _hub.CreateAsync (topic, configuration, workers));
+	}
+
+	[Fact]
+	public async Task MultipleOneToOneCreation ()
+	{
+		var topic = nameof (MultipleOneToOneCreation);
+		var tcs = new TaskCompletionSource<bool> ();
+		var worker1 = new FastWorker ("myWorkerID", tcs);
+		var worker2 = new FastWorker ("myWorkerID", tcs);
+		var workers = new [] { worker1, worker2 };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		Assert.False(await _hub.CreateAsync (topic, configuration, workers));
+	}
+
+	[Fact]
+	public async Task SingleOneToOneRegistration ()
+	{
+		var topic = nameof (SingleOneToOneRegistration);
+		var tcs = new TaskCompletionSource<bool> ();
+		var worker = new FastWorker ("myWorkerID", tcs);
+		var workers = new [] { worker };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		Assert.True (await _hub.RegisterAsync (topic, worker));
+	}
+
+	[Fact]
+	public async Task MultipleOneToOneRegistration ()
+	{
+		var topic = nameof (MultipleOneToOneRegistration);
+		var tcs = new TaskCompletionSource<bool> ();
+		var worker1 = new FastWorker ("myWorkerID", tcs);
+		var worker2 = new FastWorker ("myWorkerID", tcs);
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		Assert.True (await _hub.RegisterAsync (topic, worker1));
+		Assert.False(await _hub.RegisterAsync (topic, worker2));
+	}
+
+	[Fact]
+	public async Task MultipleOneToOneRegistrationWithLambda ()
+	{
+		var topic = nameof (MultipleOneToOneRegistrationWithLambda);
+		var tcs = new TaskCompletionSource<bool> ();
+		var worker1 = new FastWorker ("myWorkerID", tcs);
+		Func<WorkQueuesEvent, CancellationToken, Task> action = (_, _) =>
+			Task.FromResult (tcs.TrySetResult(true));
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		Assert.True (await _hub.RegisterAsync (topic, worker1));
+		Assert.False(await _hub.RegisterAsync (topic, action));
+	}
+}

--- a/Marille.Tests/WorkQueuesTests.cs
+++ b/Marille.Tests/WorkQueuesTests.cs
@@ -6,23 +6,6 @@ namespace Marille.Tests;
 // several consumers register to a queue and the compete
 // to consume an event.
 public class WorkQueuesTests {
-	struct WorkQueuesEvent (string Id);
-
-	record WorkDoneEvent (string WorkerId);
-
-	class FastWorker : IWorker<WorkQueuesEvent> {
-		public string Id { get; set; } = string.Empty;
-		public TaskCompletionSource<bool> Completion { get; private set; }
-
-		public FastWorker (string id, TaskCompletionSource<bool> tcs)
-		{
-			Id = id;
-			Completion = tcs;
-		}
-
-		public Task ConsumeAsync (WorkQueuesEvent message, CancellationToken cancellationToken = default)
-			=> Task.FromResult (Completion.TrySetResult(true));
-	}
 
 	class SlowWorker : IWorker<WorkQueuesEvent> {
 		public string Id { get; set; } = string.Empty;
@@ -40,8 +23,6 @@ public class WorkQueuesTests {
 		}
 	}
 
-	class WorkQueuesTestHub : Hub { }
-
 	Hub _hub;
 	TopicConfiguration configuration;
 	readonly CancellationTokenSource cancellationTokenSource;
@@ -50,7 +31,7 @@ public class WorkQueuesTests {
 	{
 		// use a simpler channel that we will use to receive the events when
 		// a worker has completed its work
-		_hub = new WorkQueuesTestHub ();
+		_hub = new ();
 		configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
 		cancellationTokenSource = new();
 		cancellationTokenSource.CancelAfter (TimeSpan.FromSeconds (10));


### PR DESCRIPTION
If the user declares a 1:1 topic we will not allow them to register more than one worker. This will simplify the needed understanding of the execution.