### PR TITLE
[API] Provide two execution modes for the 1:1 channels.

### DIFF
--- a/Marille.Tests/RegistrationTests.cs
+++ b/Marille.Tests/RegistrationTests.cs
@@ -16,7 +16,7 @@ public class RegistrationTests {
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new FastWorker ("myWorkerID", tcs);
 		var workers = new [] { worker };
-		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
 		Assert.True (await _hub.CreateAsync (topic, configuration, workers));
 	}
 
@@ -28,7 +28,7 @@ public class RegistrationTests {
 		var worker1 = new FastWorker ("myWorkerID", tcs);
 		var worker2 = new FastWorker ("myWorkerID", tcs);
 		var workers = new [] { worker1, worker2 };
-		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
 		Assert.False(await _hub.CreateAsync (topic, configuration, workers));
 	}
 
@@ -39,7 +39,7 @@ public class RegistrationTests {
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new FastWorker ("myWorkerID", tcs);
 		var workers = new [] { worker };
-		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
 		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
 		Assert.True (await _hub.RegisterAsync (topic, worker));
 	}
@@ -51,7 +51,7 @@ public class RegistrationTests {
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker1 = new FastWorker ("myWorkerID", tcs);
 		var worker2 = new FastWorker ("myWorkerID", tcs);
-		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
 		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
 		Assert.True (await _hub.RegisterAsync (topic, worker1));
 		Assert.False(await _hub.RegisterAsync (topic, worker2));
@@ -65,7 +65,7 @@ public class RegistrationTests {
 		var worker1 = new FastWorker ("myWorkerID", tcs);
 		Func<WorkQueuesEvent, CancellationToken, Task> action = (_, _) =>
 			Task.FromResult (tcs.TrySetResult(true));
-		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
 		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
 		Assert.True (await _hub.RegisterAsync (topic, worker1));
 		Assert.False(await _hub.RegisterAsync (topic, action));

--- a/Marille.Tests/WorkQueuesTests.cs
+++ b/Marille.Tests/WorkQueuesTests.cs
@@ -32,16 +32,19 @@ public class WorkQueuesTests {
 		// use a simpler channel that we will use to receive the events when
 		// a worker has completed its work
 		_hub = new ();
-		configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
+		configuration = new();
 		cancellationTokenSource = new();
 		cancellationTokenSource.CancelAfter (TimeSpan.FromSeconds (10));
 	}
 
 	// The simplest API usage, we register to an event for a topic with our worker
 	// and the event should be consumed and added to the completed channel for use to verify
-	[Fact]
-	public async void SingleWorker ()
+	[Theory]
+	[InlineData(ChannelDeliveryMode.AtMostOnceAsync)]
+	[InlineData(ChannelDeliveryMode.AtMostOnceSync)]
+	public async void SingleWorker (ChannelDeliveryMode deliveryMode)
 	{
+		configuration.Mode = deliveryMode;
 		var topic = "topic";
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new FastWorker ("myWorkerID", tcs);
@@ -51,9 +54,12 @@ public class WorkQueuesTests {
 		Assert.True (await tcs.Task);
 	}
 
-	[Fact]
-	public async void SingleAction ()
+	[Theory]
+	[InlineData(ChannelDeliveryMode.AtMostOnceAsync)]
+	[InlineData(ChannelDeliveryMode.AtMostOnceSync)]
+	public async void SingleAction (ChannelDeliveryMode deliveryMode)
 	{
+		configuration.Mode = deliveryMode;
 		var topic = "topic";
 		var tcs = new TaskCompletionSource<bool>();
 		Func<WorkQueuesEvent, CancellationToken, Task> action = (_, _) =>
@@ -65,9 +71,12 @@ public class WorkQueuesTests {
 		Assert.True (await tcs.Task);
 	}
 
-	[Fact]
-	public async void SeveralWorkers ()
+	[Theory]
+	[InlineData(ChannelDeliveryMode.AtMostOnceAsync)]
+	[InlineData(ChannelDeliveryMode.AtMostOnceSync)]
+	public async void SeveralWorkers (ChannelDeliveryMode deliveryMode)
 	{
+		configuration.Mode = deliveryMode;
 		string workerID = "myWorkerID";
 
 		string topic1 = "topic1";
@@ -94,7 +103,4 @@ public class WorkQueuesTests {
 		Assert.True (await tcsWorker1.Task);
 		Assert.False (tcsWorker2.Task.IsCompleted);
 	}
-
-	[Fact]
-	public void SlowFastWorker () { }
 }

--- a/Marille/ChannelDeliveryMode.cs
+++ b/Marille/ChannelDeliveryMode.cs
@@ -9,7 +9,13 @@ public enum ChannelDeliveryMode {
 	/// </summary>
 	AtLeastOnce,
 	/// <summary>
-	/// Messages in topics will be delivered just to a single worker.
+	/// Messages in topics will be delivered just to a single worker and the processing of a
+	/// message will NOT await for the task of the previous one.
 	/// </summary>
-	AtMostOnce,
+	AtMostOnceAsync,
+	/// <summary>
+	/// Messages in topics will be delivered just to a single worker and the processing of a
+	/// message will AWAIT for the task of the previous one.
+	/// </summary>
+	AtMostOnceSync,
 }


### PR DESCRIPTION
We provide two ways to execute in the 1:1 topics:

- Async: We do will not away for the task and will continue with the next item.
- Sync: We do await for the task that is consuming the current item.