### PR TITLE
[API] Add the ability to close channels and wait for all events to be flushed

### DIFF
--- a/Marille.Tests/BlockingWorker.cs
+++ b/Marille.Tests/BlockingWorker.cs
@@ -1,0 +1,17 @@
+namespace Marille.Tests;
+
+// this worked will block not consume events until the task completion source is triggered, this way
+// we can add a delay to the worker and check that several messages are present in the channel
+public class BlockingWorker (TaskCompletionSource<bool> readyToConsume) : IWorker<WorkQueuesEvent> {
+	int consumed = 0;
+	public int ConsumedCount => consumed;
+	public TaskCompletionSource<bool> ReadyToConsume { get; private set; } = readyToConsume;
+
+	public async Task ConsumeAsync (WorkQueuesEvent message, CancellationToken token = default)
+	{
+		// use this as a way to block the worker
+		await ReadyToConsume.Task;
+		// increase the count in a thread safe way
+		Interlocked.Increment(ref consumed);
+	}
+}

--- a/Marille.Tests/CancellationTests.cs
+++ b/Marille.Tests/CancellationTests.cs
@@ -1,0 +1,103 @@
+namespace Marille.Tests;
+
+public class CancellationTests {
+
+	Hub _hub;
+	TopicConfiguration configuration;
+
+	public CancellationTests ()
+	{
+		_hub = new ();
+		configuration = new();
+	}
+	[Fact]
+	public async Task CloseSingleWorkerNoEvents ()
+	{
+		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		var topic = "topic";
+		var tcs = new TaskCompletionSource<bool> ();
+		var worker = new BlockingWorker(tcs);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.RegisterAsync (topic, worker);
+		tcs.SetResult (true);
+		// publish no messages, just close the worker
+		await _hub.CloseAsync<WorkQueuesEvent> (topic);
+		Assert.Equal (0, worker.ConsumedCount);
+	}
+	
+	[Fact]
+	public async Task CloseSingleWorkerFlushedEvents ()
+	{
+		var eventCount = 100;
+		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		var topic = "topic";
+		var tcs = new TaskCompletionSource<bool> ();
+		var worker = new BlockingWorker(tcs);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.RegisterAsync (topic, worker);
+		// send several events, they will be blocked until the worker is ready to consume them
+		for (var i = 0; i < eventCount; i++) {
+			await _hub.Publish (topic, new WorkQueuesEvent($"myID{i}"));
+		}
+		tcs.SetResult (true);
+		// publish no messages, just close the worker
+		await _hub.CloseAsync<WorkQueuesEvent> (topic);
+		Assert.Equal (eventCount, worker.ConsumedCount);
+	}
+
+	[Fact]
+	public async Task CloseAllWorkersNoEvents ()
+	{
+		var eventCount = 100;
+		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		var topic1 = "topic1";
+		var tcs1 = new TaskCompletionSource<bool> ();
+		var worker1 = new BlockingWorker(tcs1);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic1, configuration);
+		await _hub.RegisterAsync (topic1, worker1);
+		
+		var topic2 = "topic2";
+		var tcs2 = new TaskCompletionSource<bool> ();
+		var worker2 = new BlockingWorker(tcs1);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic2, configuration);
+		await _hub.RegisterAsync (topic2, worker2);
+		
+		for (var i = 0; i < eventCount; i++) {
+			await _hub.Publish (topic1, new WorkQueuesEvent($"myID{i}"));
+			await _hub.Publish (topic2, new WorkQueuesEvent($"myID{i}"));
+		}
+		
+		tcs1.SetResult (true);
+		tcs2.SetResult (true);
+
+		// publish no messages, just close the worker
+		await _hub.CloseAsync<WorkQueuesEvent> (topic1);
+		Assert.Equal (eventCount, worker1.ConsumedCount);
+		Assert.Equal (eventCount, worker2.ConsumedCount);
+	}
+	
+	[Fact]
+	public async Task CloseAllWorkersFlushedEvents ()
+	{
+		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		var topic1 = "topic1";
+		var tcs1 = new TaskCompletionSource<bool> ();
+		var worker1 = new BlockingWorker(tcs1);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic1, configuration);
+		await _hub.RegisterAsync (topic1, worker1);
+		
+		var topic2 = "topic2";
+		var tcs2 = new TaskCompletionSource<bool> ();
+		var worker2 = new BlockingWorker(tcs1);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic2, configuration);
+		await _hub.RegisterAsync (topic2, worker2);
+		
+		tcs1.SetResult (true);
+		tcs2.SetResult (true);
+
+		// publish no messages, just close the worker
+		await _hub.CloseAsync<WorkQueuesEvent> (topic1);
+		Assert.Equal (0, worker1.ConsumedCount);
+		Assert.Equal (0, worker2.ConsumedCount);
+	}
+}

--- a/Marille.Tests/WorkQueuesTests.cs
+++ b/Marille.Tests/WorkQueuesTests.cs
@@ -6,23 +6,6 @@ namespace Marille.Tests;
 // several consumers register to a queue and the compete
 // to consume an event.
 public class WorkQueuesTests {
-
-	class SlowWorker : IWorker<WorkQueuesEvent> {
-		public string Id { get; set; } = string.Empty;
-		public Task ConsumeAsync (WorkQueuesEvent message, CancellationToken cancellationToken = default)
-		{
-			throw new NotImplementedException ();
-		}
-	}
-	
-	class ExceptionWorker : IWorker<WorkQueuesEvent> {
-		public string Id { get; set; } = string.Empty;
-		public Task ConsumeAsync (WorkQueuesEvent message, CancellationToken cancellationToken = default)
-		{
-			throw new NotImplementedException ();
-		}
-	}
-
 	Hub _hub;
 	TopicConfiguration configuration;
 	readonly CancellationTokenSource cancellationTokenSource;

--- a/Marille/IHub.cs
+++ b/Marille/IHub.cs
@@ -5,4 +5,7 @@ public interface IHub {
 		params IWorker<T> [] initialWorkers) where T : struct;
 	public Task<bool> RegisterAsync<T> (string topicName, params IWorker<T> [] newWorkers) where T : struct;
 	public ValueTask Publish<T> (string topicName, T publishedEvent) where T : struct;
+	public Task CloseAllAsync ();
+
+	public Task<bool> CloseAsync<T> (string topicName) where T : struct;
 }

--- a/Marille/Marille.csproj
+++ b/Marille/Marille.csproj
@@ -12,7 +12,7 @@
     <PropertyGroup>
         <Title>Marille</Title>
         <PackageId>Marille</PackageId>
-        <Version>0.3.0</Version>
+        <Version>0.4.0</Version>
         <Authors>Manuel de la Peña Saenz</Authors>
         <Owners>Manuel de la Peña Saenz</Owners>
         <Copyright>Manuel de la Peña Saenz</Copyright>


### PR DESCRIPTION
We add a new API that will allow developers to close a channel or all the channels and wait until all the events to be flushed. This API will always flush messages. We can later add an API that does not flushes the messages by using the cancellation token rather than closing the channel.