### PR TITLE
[Internal API] Remove the need of a tuple to store the consumming task.

### DIFF
--- a/Marille/Topic.cs
+++ b/Marille/Topic.cs
@@ -4,9 +4,13 @@ using System.Threading.Channels;
 namespace Marille;
 
 internal class Topic (string name) {
-	readonly Dictionary<Type, object> channels = new();
+	readonly Dictionary<Type, TopicInfo> channels = new();
 
 	public string Name { get; } = name;
+
+	public IEnumerable<Task> ConsumerTasks => from info in channels.Values
+		where info.ConsumerTask is not null
+		select info.ConsumerTask;
 
 	public bool TryGetChannel<T> ([NotNullWhen (true)] out TopicInfo<T>? channel) where T : struct
 	{

--- a/Marille/TopicInfo.cs
+++ b/Marille/TopicInfo.cs
@@ -2,11 +2,11 @@ using System.Threading.Channels;
 
 namespace Marille;
 
-internal record TopicInfo {
+internal record TopicInfo (TopicConfiguration Configuration){
 	public Task? ConsumerTask { get; set; }
 }
 
-internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel) : TopicInfo
+internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel) : TopicInfo (Configuration)
 	where T : struct {
 	public List<IWorker<T>> Workers { get; } = new();
 

--- a/Marille/TopicInfo.cs
+++ b/Marille/TopicInfo.cs
@@ -2,7 +2,11 @@ using System.Threading.Channels;
 
 namespace Marille;
 
-internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel)
+internal record TopicInfo {
+	public Task? ConsumerTask { get; set; }
+}
+
+internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel) : TopicInfo
 	where T : struct {
 	public List<IWorker<T>> Workers { get; } = new();
 


### PR DESCRIPTION
The task can be kept in the topic info which simplifies the access and later will allow us to try and remove the dictionary.