### PR TITLE
[Internal API] Remove the need for the cancellation tokens dictionary

### DIFF
--- a/Marille/Topic.cs
+++ b/Marille/Topic.cs
@@ -11,6 +11,10 @@ internal class Topic (string name) {
 	public IEnumerable<Task> ConsumerTasks => from info in channels.Values
 		where info.ConsumerTask is not null
 		select info.ConsumerTask;
+	
+	public IEnumerable<CancellationTokenSource> CancellationTokenSources => from info in channels.Values
+		where info.CancellationTokenSource is not null
+		select info.CancellationTokenSource;
 
 	public bool TryGetChannel<T> ([NotNullWhen (true)] out TopicInfo<T>? channel) where T : struct
 	{

--- a/Marille/TopicInfo.cs
+++ b/Marille/TopicInfo.cs
@@ -3,6 +3,7 @@ using System.Threading.Channels;
 namespace Marille;
 
 internal record TopicInfo (TopicConfiguration Configuration){
+	public CancellationTokenSource? CancellationTokenSource { get; set;  }
 	public Task? ConsumerTask { get; set; }
 }
 


### PR DESCRIPTION
Remove the extra data structure and move the cancellation token source to the topic information. This reduces the memory foot print and improvmes the memory management.