### PR TITLE
[API] Provide an error handling API. Fixes #31

### DIFF
--- a/Marille.Tests/CancellationTests.cs
+++ b/Marille.Tests/CancellationTests.cs
@@ -95,7 +95,7 @@ public class CancellationTests {
 		var topic2 = "topic2";
 		var tcs2 = new TaskCompletionSource<bool> ();
 		var worker2 = new BlockingWorker(tcs2);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic2, configuration);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic2, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic2, worker2);
 		
 		tcs1.SetResult (true);
@@ -169,17 +169,17 @@ public class CancellationTests {
 		var eventCount = 100;
 		var list = new List<Task> (200);
 
-		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
 		var topic1 = "topic1";
 		var tcs1 = new TaskCompletionSource<bool> ();
 		var worker1 = new BlockingWorker(tcs1);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic1, configuration);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic1, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic1, worker1);
 		
 		var topic2 = "topic2";
 		var tcs2 = new TaskCompletionSource<bool> ();
 		var worker2 = new BlockingWorker(tcs2);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic2, configuration);
+		await _hub.CreateAsync<WorkQueuesEvent> (topic2, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic2, worker2);
 		
 		for (var index = 0; index < eventCount; index++) {

--- a/Marille.Tests/CancellationTests.cs
+++ b/Marille.Tests/CancellationTests.cs
@@ -1,41 +1,43 @@
 namespace Marille.Tests;
 
 public class CancellationTests {
-
-	Hub _hub;
-	SemaphoreSlim _semaphoreSlim;
-	TopicConfiguration configuration;
+	readonly ErrorWorker<WorkQueuesEvent> _errorWorker;
+	readonly Hub _hub;
+	readonly SemaphoreSlim _semaphoreSlim;
+	TopicConfiguration _configuration;
 
 	public CancellationTests ()
 	{
 		_semaphoreSlim = new (1);
+		_errorWorker = new();
 		_hub = new (_semaphoreSlim);
-		configuration = new();
+		_configuration = new();
 	}
 	[Fact]
 	public async Task CloseSingleWorkerNoEvents ()
 	{
-		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
 		var topic = "topic";
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new BlockingWorker(tcs);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.CreateAsync (topic, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic, worker);
 		tcs.SetResult (true);
 		// publish no messages, just close the worker
 		await _hub.CloseAsync<WorkQueuesEvent> (topic);
 		Assert.Equal (0, worker.ConsumedCount);
+		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 	
 	[Fact]
 	public async Task CloseSingleWorkerFlushedEvents ()
 	{
 		var eventCount = 100;
-		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
 		var topic = "topic";
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new BlockingWorker(tcs);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.CreateAsync (topic, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic, worker);
 		// send several events, they will be blocked until the worker is ready to consume them
 		for (var i = 0; i < eventCount; i++) {
@@ -45,23 +47,24 @@ public class CancellationTests {
 		// publish no messages, just close the worker
 		await _hub.CloseAsync<WorkQueuesEvent> (topic);
 		Assert.Equal (eventCount, worker.ConsumedCount);
+		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 
 	[Fact]
 	public async Task CloseAllWorkersFlushedEvents ()
 	{
 		var eventCount = 100;
-		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
 		var topic1 = "topic1";
 		var tcs1 = new TaskCompletionSource<bool> ();
 		var worker1 = new BlockingWorker(tcs1);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic1, configuration);
+		await _hub.CreateAsync (topic1, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic1, worker1);
 		
 		var topic2 = "topic2";
 		var tcs2 = new TaskCompletionSource<bool> ();
 		var worker2 = new BlockingWorker(tcs1);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic2, configuration);
+		await _hub.CreateAsync (topic2, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic2, worker2);
 		
 		for (var i = 0; i < eventCount; i++) {
@@ -76,22 +79,23 @@ public class CancellationTests {
 		await _hub.CloseAsync<WorkQueuesEvent> (topic1);
 		Assert.NotEqual (0, worker1.ConsumedCount);
 		Assert.NotEqual (0, worker2.ConsumedCount);
+		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 	
 	[Fact]
 	public async Task CloseAllWorkersNoEvents ()
 	{
-		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
 		var topic1 = "topic1";
 		var tcs1 = new TaskCompletionSource<bool> ();
 		var worker1 = new BlockingWorker(tcs1);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic1, configuration);
+		await _hub.CreateAsync (topic1, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic1, worker1);
 		
 		var topic2 = "topic2";
 		var tcs2 = new TaskCompletionSource<bool> ();
 		var worker2 = new BlockingWorker(tcs1);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic2, configuration);
+		await _hub.CreateAsync (topic2, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic2, worker2);
 		
 		tcs1.SetResult (true);
@@ -101,6 +105,7 @@ public class CancellationTests {
 		await _hub.CloseAsync<WorkQueuesEvent> (topic1);
 		Assert.Equal (0, worker1.ConsumedCount);
 		Assert.Equal (0, worker2.ConsumedCount);
+		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 
 	[Fact]
@@ -113,9 +118,9 @@ public class CancellationTests {
 		
 		// create the topic and then try to close if from several threads ensuring that only one of them
 		// closes the channel.
-		configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
 		var topic = nameof (MultithreadedClose);
-		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.CreateAsync (topic, _configuration, _errorWorker);
 		
 		// block the closing until we have created all the needed threads
 		await _semaphoreSlim.WaitAsync ();
@@ -153,5 +158,6 @@ public class CancellationTests {
 			}
 		}
 		Assert.False (finalResult);
+		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 }

--- a/Marille.Tests/ErrorHandlingTests.cs
+++ b/Marille.Tests/ErrorHandlingTests.cs
@@ -1,0 +1,75 @@
+namespace Marille.Tests;
+
+public class ErrorHandlingTests {
+
+	readonly Hub _hub;
+	readonly ErrorWorker<WorkQueuesEvent> _errorWorker;
+	readonly TaskCompletionSource<bool> _errorWorkerTcs;
+	TopicConfiguration _configuration;
+
+	public ErrorHandlingTests ()
+	{
+		_hub = new();
+		_errorWorkerTcs = new();
+		_errorWorker = new(_errorWorkerTcs);
+		_configuration = new();
+	}
+	
+	[Fact]
+	public async Task ErrorWorkerConsumeAsync ()
+	{
+		// create a new topic, post 3 events and consume them, one of them will throw an exception
+		// and we should be able to handle it appropriately
+		var topic = nameof(ErrorLambdaConsumeAsync);
+		var workerTcs = new TaskCompletionSource<bool> ();
+		var worker = new FastWorker ("worker1", workerTcs);
+		await _hub.CreateAsync (topic, _configuration, _errorWorker, worker);
+		// we will post 3 events, one of them will throw an exception
+		await _hub.Publish (topic, new WorkQueuesEvent ("1"));
+		await _hub.Publish (topic, new WorkQueuesEvent ("2", true));
+		await _hub.Publish (topic, new WorkQueuesEvent ("3"));
+		// await for the error worker to consume the events
+		await _errorWorkerTcs.Task;
+		Assert.Equal (1, _errorWorker.ConsumedCount);
+		// assert the id of the message and the exception
+		Assert.Equal ("2", _errorWorker.ConsumedMessages[0].Message.Id);
+		Assert.Equal (typeof(InvalidOperationException), 
+			_errorWorker.ConsumedMessages[0].Exception.InnerException!.GetType ());
+	}
+	
+	[Fact]
+	public async Task ErrorLambdaConsumeAsync ()
+	{
+		// use the lambda notation to consume the events and assert that the error worker is called correctly
+		var topic = nameof(ErrorLambdaConsumeAsync);
+		int consumedCount = 0;
+		var messageId = string.Empty;
+		var tcs = new TaskCompletionSource<bool> ();
+		Exception? exception = null;
+		Func<WorkQueuesEvent, Exception, CancellationToken, Task> errorAction = (message, exceptionIn, _) => {
+			Interlocked.Increment (ref consumedCount);
+			messageId = message.Id;
+			exception = exceptionIn; 
+			tcs.TrySetResult (true);
+			return Task.FromResult (Task.CompletedTask);
+		};
+		Func<WorkQueuesEvent, CancellationToken, Task> workerAction = (message, token) => {
+			if (message.IsError) {
+				throw new InvalidOperationException($"Message with Id {message.Id} is an error");
+			}
+			return Task.CompletedTask;
+		};
+		await _hub.CreateAsync (topic, _configuration, errorAction, workerAction);
+		// we will post 3 events, one of them will throw an exception
+		await _hub.Publish (topic, new WorkQueuesEvent ("1"));
+		await _hub.Publish (topic, new WorkQueuesEvent ("2", true));
+		await _hub.Publish (topic, new WorkQueuesEvent ("3"));
+		// await for the error worker to consume the events
+		await tcs.Task;
+		Assert.Equal (1, consumedCount);
+		// assert the id of the message and the exception
+		Assert.Equal ("2", messageId);
+		Assert.Equal (typeof(InvalidOperationException), 
+			exception?.InnerException!.GetType ());
+	}
+}

--- a/Marille.Tests/ErrorWorker.cs
+++ b/Marille.Tests/ErrorWorker.cs
@@ -1,0 +1,30 @@
+namespace Marille.Tests;
+
+public class ErrorWorker<T> : IErrorWorker<T> where T :  struct {
+
+	SemaphoreSlim _semaphoreSlim = new (1);
+	int _consumedCount;
+	public int ConsumedCount => _consumedCount;
+	public List<(T Message, Exception Exception)> ConsumedMessages { get; private set; } = new();
+
+	public TaskCompletionSource<bool> TaskCompletionSource { get; private set; } = new();
+	
+	public ErrorWorker () {}
+	
+	public ErrorWorker (TaskCompletionSource<bool> tcs)
+	{
+		TaskCompletionSource = tcs;
+	}
+	
+	public async Task ConsumeAsync (T message, Exception exception, CancellationToken token = default)
+	{
+		await _semaphoreSlim.WaitAsync ();
+		try {
+			ConsumedMessages.Add ((message, exception));
+			Interlocked.Increment (ref _consumedCount);
+			TaskCompletionSource.TrySetResult (true);
+		} finally {
+			_semaphoreSlim.Release ();
+		}
+	}
+}

--- a/Marille.Tests/FastWorker.cs
+++ b/Marille.Tests/FastWorker.cs
@@ -1,12 +1,22 @@
 namespace Marille.Tests;
 
-public struct WorkQueuesEvent (string Id);
+public struct WorkQueuesEvent {
+
+	public string Id { get; private set;}
+	public bool IsError { get; private set; }
+	public WorkQueuesEvent (string id, bool isError = false)
+	{
+		Id = id;
+		IsError = isError;
+		
+	}
+}
 
 public record WorkDoneEvent (string WorkerId);
 
 public class FastWorker : IWorker<WorkQueuesEvent> {
 	public string Id { get; set; } = string.Empty;
-	public TaskCompletionSource<bool> Completion { get; private set; }
+	public TaskCompletionSource<bool> Completion { get; }
 
 	public FastWorker (string id, TaskCompletionSource<bool> tcs)
 	{
@@ -15,5 +25,7 @@ public class FastWorker : IWorker<WorkQueuesEvent> {
 	}
 
 	public Task ConsumeAsync (WorkQueuesEvent message, CancellationToken cancellationToken = default)
-		=> Task.FromResult (Completion.TrySetResult(true));
+		=> message.IsError ? 
+			Task.FromException (new InvalidOperationException($"Message with Id {message.Id} is an error")) :
+			Task.FromResult (Completion.TrySetResult(true));
 }

--- a/Marille.Tests/RegistrationTests.cs
+++ b/Marille.Tests/RegistrationTests.cs
@@ -9,6 +9,7 @@ public class RegistrationTests {
 	{
 		_semaphoreSlim = new(1);
 		_hub = new (_semaphoreSlim);
+		_errorWorker = new();
 	} 
 
 	[Fact]

--- a/Marille.Tests/RegistrationTests.cs
+++ b/Marille.Tests/RegistrationTests.cs
@@ -1,9 +1,9 @@
 namespace Marille.Tests;
 
 public class RegistrationTests {
-
-	Hub _hub;
-	SemaphoreSlim _semaphoreSlim;
+	readonly Hub _hub;
+	readonly ErrorWorker<WorkQueuesEvent> _errorWorker;
+	readonly SemaphoreSlim _semaphoreSlim;
 
 	public RegistrationTests ()
 	{
@@ -19,7 +19,7 @@ public class RegistrationTests {
 		var worker = new FastWorker ("myWorkerID", tcs);
 		var workers = new [] { worker };
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		Assert.True (await _hub.CreateAsync (topic, configuration, workers));
+		Assert.True (await _hub.CreateAsync (topic, configuration, _errorWorker, workers));
 	}
 
 	[Fact]
@@ -31,7 +31,7 @@ public class RegistrationTests {
 		var worker2 = new FastWorker ("myWorkerID", tcs);
 		var workers = new [] { worker1, worker2 };
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		Assert.False(await _hub.CreateAsync (topic, configuration, workers));
+		Assert.False(await _hub.CreateAsync (topic, configuration, _errorWorker, workers));
 	}
 
 	[Fact]
@@ -41,7 +41,7 @@ public class RegistrationTests {
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new FastWorker ("myWorkerID", tcs);
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.CreateAsync (topic, configuration, _errorWorker);
 		Assert.True (await _hub.RegisterAsync (topic, worker));
 	}
 
@@ -53,7 +53,7 @@ public class RegistrationTests {
 		var worker1 = new FastWorker ("myWorkerID", tcs);
 		var worker2 = new FastWorker ("myWorkerID", tcs);
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.CreateAsync (topic, configuration, _errorWorker);
 		Assert.True (await _hub.RegisterAsync (topic, worker1));
 		Assert.False(await _hub.RegisterAsync (topic, worker2));
 	}
@@ -67,7 +67,7 @@ public class RegistrationTests {
 		Func<WorkQueuesEvent, CancellationToken, Task> action = (_, _) =>
 			Task.FromResult (tcs.TrySetResult(true));
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+		await _hub.CreateAsync (topic, configuration, _errorWorker);
 		Assert.True (await _hub.RegisterAsync (topic, worker1));
 		Assert.False(await _hub.RegisterAsync (topic, action));
 	}
@@ -96,7 +96,7 @@ public class RegistrationTests {
 				// random sleep to ensure that the other thread is also trying to create
 				var sleep = random.Next (1000);
 				await Task.Delay (TimeSpan.FromMilliseconds (sleep));
-				var created = await _hub.CreateAsync<WorkQueuesEvent> (topic, configuration);
+				var created = await _hub.CreateAsync (topic, configuration, _errorWorker);
 				tcs.TrySetResult (created);
 			});
 		}

--- a/Marille/IErrorWorker.cs
+++ b/Marille/IErrorWorker.cs
@@ -1,0 +1,6 @@
+namespace Marille;
+
+public interface IErrorWorker<in T> where T :  struct {
+
+	public Task ConsumeAsync (T message, Exception exception, CancellationToken token = default);
+}

--- a/Marille/IHub.cs
+++ b/Marille/IHub.cs
@@ -16,10 +16,11 @@ public interface IHub {
 	/// <param name="topicName">The topic used to identify the channel. The same topic can have channels for different
 	/// types of events, but the combination (topicName, eventType) has to be unique.</param>
 	/// <param name="configuration">The configuration to use for the channel creation.</param>
+	/// <param name="errorWorker">Worker that will receive any error from faulty worker executions.</param>
 	/// <param name="initialWorkers">Original set of IWorker&lt;T&gt; to be assigned the channel on creation.</param>
 	/// <typeparam name="T">The event type to be used for the channel.</typeparam>
 	/// <returns>true when the channel was created.</returns>
-	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration,
+	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration, IErrorWorker<T> errorWorker,
 		params IWorker<T> [] initialWorkers) where T : struct;
 
 	/// <summary>
@@ -31,10 +32,11 @@ public interface IHub {
 	/// <param name="topicName">The topic used to identify the channel. The same topic can have channels for different
 	/// types of events, but the combination (topicName, eventType) has to be unique.</param>
 	/// <param name="configuration">The configuration to use for the channel creation.</param>
+	/// <param name="errorWorker">Worker that will receive any error from faulty worker executions.</param>
 	/// <param name="initialWorkers">Original set of IWorker&lt;T&gt; to be assigned the channel on creation.</param>
 	/// <typeparam name="T">The event type to be used for the channel.</typeparam>
 	/// <returns>true when the channel was created.</returns>
-	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration,
+	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration, IErrorWorker<T> errorWorker,
 		IEnumerable<IWorker<T>> initialWorkers) where T : struct;
 
 	/// <summary>
@@ -44,10 +46,12 @@ public interface IHub {
 	/// <param name="topicName">The topic used to identify the channel. The same topic can have channels for different
 	/// types of events, but the combination (topicName, eventType) has to be unique.</param>
 	/// <param name="configuration">The configuration to use for the channel creation.</param>
+	/// <param name="errorAction">Worker that will receive any error from faulty worker executions.</param>
 	/// <param name="actions">A set of functions that will be executed when an item is delivered.</param>
 	/// <typeparam name="T">The event type to be used for the channel.</typeparam>
 	/// <returns>true when the channel was created.</returns>
-	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration,
+	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration, 
+		Func<T, Exception, CancellationToken, Task> errorAction,
 		params Func<T, CancellationToken, Task> [] actions) where T : struct;
 
 	/// <summary>
@@ -57,12 +61,14 @@ public interface IHub {
 	/// <param name="topicName">The topic used to identify the channel. The same topic can have channels for different
 	/// types of events, but the combination (topicName, eventType) has to be unique.</param>
 	/// <param name="configuration">The configuration to use for the channel creation.</param>
+	/// <param name="errorAction">Worker that will receive any error from faulty worker executions.</param>
 	/// <param name="action">The function that will be executed when a message is delivered.</param>
 	/// <typeparam name="T">The event type to be used for the channel.</typeparam>
 	/// <returns>true when the channel was created.</returns>
-	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration,
+	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration, 
+		Func<T, Exception, CancellationToken, Task> errorAction,
 		Func<T, CancellationToken, Task> action) where T : struct;
-	
+
 	/// <summary>
 	/// Attempts to create a new channel for the given topic name using the provided configuration. Channels cannot
 	/// be created more than once, in case the channel already exists this method returns false;
@@ -72,9 +78,26 @@ public interface IHub {
 	/// <param name="topicName">The topic used to identify the channel. The same topic can have channels for different
 	/// types of events, but the combination (topicName, eventType) has to be unique.</param>
 	/// <param name="configuration">The configuration to use for the channel creation.</param>
+	/// <param name="errorWorker">Worker that will receive any error from faulty worker executions.</param>
 	/// <typeparam name="T">The event type to be used for the channel.</typeparam>
 	/// <returns>true when the channel was created.</returns>
-	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration) where T : struct;
+	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration,
+		IErrorWorker<T> errorWorker) where T : struct;
+
+	/// <summary>
+	/// Attempts to create a new channel for the given topic name using the provided configuration. Channels cannot
+	/// be created more than once, in case the channel already exists this method returns false;
+	///
+	/// No workers will be assigned to the channel upon creation.
+	/// </summary>
+	/// <param name="topicName">The topic used to identify the channel. The same topic can have channels for different
+	/// types of events, but the combination (topicName, eventType) has to be unique.</param>
+	/// <param name="configuration">The configuration to use for the channel creation.</param>
+	/// <param name="errorAction">Worker that will receive any error from faulty worker executions.</param>
+	/// <typeparam name="T">The event type to be used for the channel.</typeparam>
+	/// <returns>true when the channel was created.</returns>
+	public Task<bool> CreateAsync<T> (string topicName, TopicConfiguration configuration,
+		Func<T, Exception, CancellationToken, Task> errorAction) where T : struct;
 
 	/// <summary>
 	/// Attempts to register new workers to consume messages for the given topic.

--- a/Marille/LambdaErrorWorker.cs
+++ b/Marille/LambdaErrorWorker.cs
@@ -1,0 +1,6 @@
+namespace Marille;
+
+internal class LambdaErrorWorker<T> (Func<T, Exception, CancellationToken, Task> lambda) : IErrorWorker<T> where T : struct {
+	public Task ConsumeAsync (T message, Exception exception, CancellationToken cancellationToken = default)
+		=> lambda (message, exception, cancellationToken);
+}

--- a/Marille/LambdaWorker.cs
+++ b/Marille/LambdaWorker.cs
@@ -1,6 +1,9 @@
 namespace Marille;
 
 internal class LambdaWorker<T> (Func<T, CancellationToken,Task> lambda) : IWorker<T> where T : struct {
-	public Task ConsumeAsync (T message, CancellationToken cancellationToken = default)
-		=> lambda (message, cancellationToken);
+	public async Task ConsumeAsync (T message, CancellationToken cancellationToken = default)
+	{
+		// await the lambda function so that we can wrap any exceptions in a Task
+		await lambda (message, cancellationToken);
+	}
 }

--- a/Marille/Marille.csproj
+++ b/Marille/Marille.csproj
@@ -18,7 +18,7 @@
     <PropertyGroup>
         <Title>Marille</Title>
         <PackageId>Marille</PackageId>
-        <Version>0.4.2</Version>
+        <Version>0.5.0</Version>
         <Authors>Manuel de la Peña Saenz</Authors>
         <Owners>Manuel de la Peña Saenz</Owners>
         <Copyright>Manuel de la Peña Saenz</Copyright>

--- a/Marille/Message.cs
+++ b/Marille/Message.cs
@@ -1,13 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Marille;
 
 internal enum MessageType {
 	Ack,
-	Data
+	Data,
+	Error,
 }
 internal struct Message<T> where T : struct {
 	public Guid Id { get; }
 	public MessageType Type { get; }
+
+	[MemberNotNullWhen(true, nameof(Exception))]
+	public bool IsError => Type == MessageType.Error;
 	public T Payload { get; }
+	public Exception? Exception { get; }
 
 	public Message (MessageType type)
 	{
@@ -15,10 +22,13 @@ internal struct Message<T> where T : struct {
 		Type = type;
 		Payload = default;
 	}
-	public Message (MessageType type, T payload)
+	public Message (MessageType type, T payload) : this(type)
 	{
 		Id = Guid.NewGuid();
-		Type = type;
 		Payload = payload;
+	}
+	public Message (T payload, Exception exception) : this(MessageType.Error, payload)
+	{
+		Exception = exception;
 	}
 }

--- a/Marille/Topic.cs
+++ b/Marille/Topic.cs
@@ -26,13 +26,15 @@ internal class Topic (string name) {
 		return channel is not null;
 	}
 
-	public TopicInfo<T> CreateChannel<T> (TopicConfiguration configuration, params IWorker<T>[] workers) where T : struct
+	public TopicInfo<T> CreateChannel<T> (TopicConfiguration configuration, IErrorWorker<T> errorWorker,
+		params IWorker<T>[] workers) where T : struct
 	{
 		Type type = typeof (T);
 		if (!TryGetChannel<T> (out var obj)) {
 			var ch = (configuration.Capacity is null) ? 
-				Channel.CreateUnbounded<Message<T>> () : Channel.CreateBounded<Message<T>> (configuration.Capacity.Value);
-			obj = new(configuration, ch, workers);
+				Channel.CreateUnbounded<Message<T>> () : 
+				Channel.CreateBounded<Message<T>> (configuration.Capacity.Value);
+			obj = new(configuration, ch, errorWorker, workers);
 			channels[type] = obj; 
 		}
 

--- a/Marille/TopicInfo.cs
+++ b/Marille/TopicInfo.cs
@@ -7,13 +7,14 @@ internal record TopicInfo (TopicConfiguration Configuration){
 	public Task? ConsumerTask { get; set; }
 }
 
-internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel) : TopicInfo (Configuration)
+internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel, IErrorWorker<T> ErrorWorker) : TopicInfo (Configuration)
 	where T : struct {
 	public List<IWorker<T>> Workers { get; } = new();
 
-	public TopicInfo (TopicConfiguration configuration, Channel<Message<T>> channel,
-		params IWorker<T> [] workers) : this(configuration, channel)
+	public TopicInfo (TopicConfiguration configuration, Channel<Message<T>> channel, IErrorWorker<T> errorWorker,
+		params IWorker<T> [] workers) : this(configuration, channel, errorWorker)
 	{
+		ErrorWorker = errorWorker;
 		Workers.AddRange (workers);
 	}
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ class MyWorker : IWorker<MyMessage> {
        => Task.FromResult (Completion.TrySetResult(true));
 }
 
+// creeate an error worker to handle exceptions from workers
+class ErrorWorker : IErrorWorker<MyMessage> {
+    public Task ConsumeAsync (MyMessage message, Exception exception, CancellationToken cancellationToken = default)
+        => Task.FromResult (Completion.TrySetResult(true));
+}
+
 ```
 
 2. Setup the topic via a new Hub:
@@ -52,9 +58,10 @@ public Task CreateChannels () {
     var configuration = new() { Mode = ChannelDeliveryMode.AtMostOnce };
     var topic = "topic";
     var worker = new MyWorker ();
+    var errorWorker = new ErrorWorker ();
     // workers can be either added during the channel creation or after the fact
     // with the TryRegister method.
-    return _hub.CreateAsync (topic, configuration, worker);
+    return _hub.CreateAsync (topic, configuration, errorWorer, worker);
 }
 ```
 
@@ -85,3 +92,14 @@ await _hub.CloseAsync<MyMessage> (topic);
 // close all topcis
 await _hub.CloseAsync<MyMessage> (topic1);
 ```
+
+5. Error handling
+
+The library provides a way to handle exceptions that are thrown by the workers. The error worker will be called
+whenever an exception is thrown by a worker that is consuming a topic. It is up to the implementation to decide 
+if the message should be retried or not. 
+
+If we do not want to retry a message a worker can throw and exception, such exception will be added to a queue that 
+will be consumed by the error worker that was used when the topic was created. Each topic has its own error queue, that
+means that the error worker will only consume errors from the topic that it was created for.
+

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ await _hub.CloseAsync<MyMessage> (topic1);
 
 5. Error handling
 
-The library provides a way to handle exceptions that are thrown by the workers. The error worker will be called
+The library provides a way to handle exceptions that are thrown by the workers. The error worker is called
 whenever an exception is thrown by a worker that is consuming a topic. It is up to the implementation to decide 
 if the message should be retried or not. 
 


### PR DESCRIPTION
In order to be able to handle errors/exception from workers we are going to provide an API that allows to register an ErrorWorker per topic.

This API allows a worker that is registed to a topic to throw an exception, this exception later will be wrapped in an event passed to the error worker. The event will provide the following data:

1. Message: The message that generated the exception.
2. The exception that was thrown.

Fixes #31 