### PR TITLE
[API] Execute several workers in parallel but wait before we advance

### DIFF
--- a/Marille.Tests/CancellationTests.cs
+++ b/Marille.Tests/CancellationTests.cs
@@ -16,7 +16,7 @@ public class CancellationTests {
 	[Fact]
 	public async Task CloseSingleWorkerNoEvents ()
 	{
-		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnceAsync;
 		var topic = "topic";
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new BlockingWorker(tcs);
@@ -33,7 +33,7 @@ public class CancellationTests {
 	public async Task CloseSingleWorkerFlushedEvents ()
 	{
 		var eventCount = 100;
-		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnceAsync;
 		var topic = "topic";
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new BlockingWorker(tcs);
@@ -54,7 +54,7 @@ public class CancellationTests {
 	public async Task CloseAllWorkersFlushedEvents ()
 	{
 		var eventCount = 100;
-		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnceAsync;
 		var topic1 = "topic1";
 		var tcs1 = new TaskCompletionSource<bool> ();
 		var worker1 = new BlockingWorker(tcs1);
@@ -85,7 +85,7 @@ public class CancellationTests {
 	[Fact]
 	public async Task CloseAllWorkersNoEvents ()
 	{
-		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnceAsync;
 		var topic1 = "topic1";
 		var tcs1 = new TaskCompletionSource<bool> ();
 		var worker1 = new BlockingWorker(tcs1);
@@ -118,7 +118,7 @@ public class CancellationTests {
 		
 		// create the topic and then try to close if from several threads ensuring that only one of them
 		// closes the channel.
-		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnceAsync;
 		var topic = nameof (MultithreadedClose);
 		await _hub.CreateAsync (topic, _configuration, _errorWorker);
 		
@@ -169,7 +169,7 @@ public class CancellationTests {
 		var eventCount = 100;
 		var list = new List<Task> (200);
 
-		_configuration.Mode = ChannelDeliveryMode.AtLeastOnce;
+		_configuration.Mode = ChannelDeliveryMode.AtLeastOnceAsync;
 		var topic1 = "topic1";
 		var tcs1 = new TaskCompletionSource<bool> ();
 		var worker1 = new BlockingWorker(tcs1);

--- a/Marille.Tests/PublishSubscribeTests.cs
+++ b/Marille.Tests/PublishSubscribeTests.cs
@@ -59,7 +59,8 @@ public class PublishSubscribeTests {
 			var worker = new SleepyWorker($"worker{index + 1}", tcs);
 			workers.Add ((worker, tcs));
 		}
-		var topic = "topic";
+
+		var topic = nameof (SingleProducerSeveralSleepyConsumers);
 		await _hub.CreateAsync (topic, _configuration, _errorWorker, workers.Select (x => x.Worker));
 		// publish a single message that will be received by all workers meaning we should wait for ALL their
 		// task completion sources to be done

--- a/Marille/ChannelDeliveryMode.cs
+++ b/Marille/ChannelDeliveryMode.cs
@@ -7,15 +7,20 @@ public enum ChannelDeliveryMode {
 	/// <summary>
 	/// Messages in topics will be delivered to all workers.
 	/// </summary>
-	AtLeastOnce,
+	AtLeastOnceAsync = 0,
+	/// <summary>
+	/// Messages in topics will be delivered to all workers and the processing of a message will
+	/// wait for the tasks of the previous one.
+	/// </summary>
+	AtLeastOnceSync = 1,
 	/// <summary>
 	/// Messages in topics will be delivered just to a single worker and the processing of a
 	/// message will NOT await for the task of the previous one.
 	/// </summary>
-	AtMostOnceAsync,
+	AtMostOnceAsync = 2,
 	/// <summary>
 	/// Messages in topics will be delivered just to a single worker and the processing of a
 	/// message will AWAIT for the task of the previous one.
 	/// </summary>
-	AtMostOnceSync,
+	AtMostOnceSync = 3,
 }

--- a/Marille/TopicConfiguration.cs
+++ b/Marille/TopicConfiguration.cs
@@ -7,7 +7,7 @@ public struct TopicConfiguration () {
 	/// <summary>
 	/// The mode that will be used to dispatch messages among the different workers.
 	/// </summary>
-	public	ChannelDeliveryMode Mode { get; set; } = ChannelDeliveryMode.AtLeastOnce;
+	public ChannelDeliveryMode Mode { get; set; } = ChannelDeliveryMode.AtLeastOnceAsync;
 
 	/// <summary>
 	/// The capacity that the channel will have. When a channel is full, producers will be


### PR DESCRIPTION
This adds a new mode that allow to have several workers in the same topic that will execute in parallel yet we will wait for all of them to complete BEFORE we move fwd.

We also remove capturing lambdas for better memory management.

Fixes #34