### PR TITLE
[API] Proivide a sync API to publish events.

### DIFF
--- a/src/Marille.Tests/CancellationTests.cs
+++ b/src/Marille.Tests/CancellationTests.cs
@@ -49,7 +49,7 @@ public class CancellationTests : IDisposable {
 		await _hub.RegisterAsync (topic, worker);
 		// send several events, they will be blocked until the worker is ready to consume them
 		for (var i = 0; i < eventCount; i++) {
-			await _hub.Publish (topic, new WorkQueuesEvent($"myID{i}"));
+			await _hub.PublishAsync (topic, new WorkQueuesEvent($"myID{i}"));
 		}
 		tcs.SetResult (true);
 		// publish no messages, just close the worker
@@ -76,8 +76,8 @@ public class CancellationTests : IDisposable {
 		await _hub.RegisterAsync (topic2, worker2);
 		
 		for (var i = 0; i < eventCount; i++) {
-			await _hub.Publish (topic1, new WorkQueuesEvent($"myID{i}"));
-			await _hub.Publish (topic2, new WorkQueuesEvent($"myID{i}"));
+			await _hub.PublishAsync (topic1, new WorkQueuesEvent($"myID{i}"));
+			await _hub.PublishAsync (topic2, new WorkQueuesEvent($"myID{i}"));
 		}
 		
 		tcs1.SetResult (true);
@@ -191,8 +191,8 @@ public class CancellationTests : IDisposable {
 		await _hub.RegisterAsync (topic2, worker2);
 		
 		for (var index = 0; index < eventCount; index++) {
-			await _hub.Publish (topic1, new WorkQueuesEvent($"myID{index}"));
-			await _hub.Publish (topic2, new WorkQueuesEvent($"myID{index}"));
+			await _hub.PublishAsync (topic1, new WorkQueuesEvent($"myID{index}"));
+			await _hub.PublishAsync (topic2, new WorkQueuesEvent($"myID{index}"));
 		}
 		
 		// we are blocking the consume of the channels

--- a/src/Marille.Tests/ErrorHandlingTests.cs
+++ b/src/Marille.Tests/ErrorHandlingTests.cs
@@ -31,9 +31,9 @@ public class ErrorHandlingTests : IDisposable {
 		var worker = new FastWorker ("worker1", workerTcs);
 		await _hub.CreateAsync (topic, _configuration, _errorWorker, worker);
 		// we will post 3 events, one of them will throw an exception
-		await _hub.Publish (topic, new WorkQueuesEvent ("1"));
-		await _hub.Publish (topic, new WorkQueuesEvent ("2", true));
-		await _hub.Publish (topic, new WorkQueuesEvent ("3"));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("1"));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("2", true));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("3"));
 		// await for the error worker to consume the events
 		await _errorWorkerTcs.Task;
 		Assert.Equal (1, _errorWorker.ConsumedCount);
@@ -67,9 +67,9 @@ public class ErrorHandlingTests : IDisposable {
 		};
 		await _hub.CreateAsync (topic, _configuration, errorAction, workerAction);
 		// we will post 3 events, one of them will throw an exception
-		await _hub.Publish (topic, new WorkQueuesEvent ("1"));
-		await _hub.Publish (topic, new WorkQueuesEvent ("2", true));
-		await _hub.Publish (topic, new WorkQueuesEvent ("3"));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("1"));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("2", true));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("3"));
 		// await for the error worker to consume the events
 		await tcs.Task;
 		Assert.Equal (1, consumedCount);

--- a/src/Marille.Tests/WorkQueuesTests.cs
+++ b/src/Marille.Tests/WorkQueuesTests.cs
@@ -42,7 +42,7 @@ public class WorkQueuesTests : IDisposable {
 		var worker = new FastWorker ("myWorkerID", tcs);
 		await _hub.CreateAsync (topic, _configuration, _errorWorker);
 		await _hub.RegisterAsync (topic, worker);
-		await _hub.Publish (topic, new WorkQueuesEvent ("myID"));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("myID"));
 		Assert.True (await tcs.Task);
 		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
@@ -60,7 +60,7 @@ public class WorkQueuesTests : IDisposable {
 
 		await _hub.CreateAsync (topic, _configuration, _errorWorker);
 		Assert.True (await _hub.RegisterAsync (topic, action));
-		await _hub.Publish (topic, new WorkQueuesEvent("myID"));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent("myID"));
 		Assert.True (await tcs.Task);
 		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
@@ -91,7 +91,7 @@ public class WorkQueuesTests : IDisposable {
 		Assert.True (await _hub.RegisterAsync (topic2, worker2));
 
 		// publish two both topics and ensure that each of the workers gets teh right data
-		await _hub.Publish (topic1, new WorkQueuesEvent ("1"));
+		await _hub.PublishAsync (topic1, new WorkQueuesEvent ("1"));
 
 		// we should only get the event in topic one, the second topic should be ignored
 		Assert.True (await tcsWorker1.Task);
@@ -118,7 +118,7 @@ public class WorkQueuesTests : IDisposable {
 
 		var topic = nameof (SeveralWorkersSyncCall);
 		await _hub.CreateAsync (topic, configuration, _errorWorker, workers.Select (x => x.Worker));
-		await _hub.Publish (topic, new WorkQueuesEvent ("myID"));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("myID"));
 		var result = await Task.WhenAll (workers.Select (x => x.Tcs.Task));
 		Assert.Equal (workerCount, result.Length);
 		// assert that all did indeed return true
@@ -150,7 +150,7 @@ public class WorkQueuesTests : IDisposable {
 		var fastWorker = new FastWorker ("fast1", fastTcs);
 		allWorkers.Add (fastWorker);
 		await _hub.CreateAsync (topic, configuration, _errorWorker, allWorkers);
-		await _hub.Publish (topic, new WorkQueuesEvent ("myID", true));
+		await _hub.PublishAsync (topic, new WorkQueuesEvent ("myID", true));
 		var result = await Task.WhenAll (workers.Select (x => x.Tcs.Task));
 		Assert.Equal (workerCount, result.Length);
 		// assert that all did indeed return true

--- a/src/Marille/IHub.cs
+++ b/src/Marille/IHub.cs
@@ -133,7 +133,20 @@ public interface IHub : IDisposable, IAsyncDisposable {
 	/// <returns>true of the message was delivered to the topic.</returns>
 	/// <exception cref="InvalidOperationException">Thrown if no topic can be found with the provided
 	/// (topicName, messageType) combination.</exception>
-	public ValueTask Publish<T> (string topicName, T publishedEvent) where T : struct;
+	public ValueTask PublishAsync<T> (string topicName, T publishedEvent) where T : struct;
+	
+	/// <summary>
+	/// Allows to publish a message in the given topic. The method will fail on bounded channels depending on the
+	/// semantics that were used to create the channel.
+	/// </summary>
+	/// <param name="topicName">The topic name that will deliver messages to the worker.</param>
+	/// <param name="publishedEvent">The message to be publish in the topic.</param>
+	/// <typeparam name="T">The type of messages of the topic.</typeparam>
+	/// <returns>true of the message was delivered to the topic.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if no topic can be found with the provided
+	/// (topicName, messageType) combination.</exception>
+	/// <returns>true if the event could be publish.</returns>
+	public bool TryPublish<T> (string topicName, T publishedEvent) where T : struct;
 	
 	/// <summary>
 	/// Cancel all channels in the Hub and return a task that will be completed once all the channels have been flushed.


### PR DESCRIPTION
There are centain cases in which we cannot use async methods, for example on events. The TryPublish method solves that situation allowing to publish an event in the channel with a sync API that will fail if the channel cannot receive more events rather than wait for ever.