### PR TITLE
[API] Allow workers to be CPU intensive.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 *.idea
+
+# Mac OS annoying files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ messages that they distribute. The normal pattern for usage is as follows:
 You can think about Marille as an in-process pub/sub similar to a distributed queue with the difference
 that the constraints are much simpler. Working within the same process makes dealing with failure much easier.
 
-The library does not impose any thread usage and it fully relies on the default [TaskScheduler](https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-threading-tasks-taskscheduler) used in the application, that is, there are no Task.Run calls to be found in the 
-source of the library. 
+The library does not impose any thread usage and it fully relies on the default [TaskScheduler](https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-threading-tasks-taskscheduler) used in 
+the application.
 
 ## Examples
 
@@ -33,13 +33,18 @@ public record struct MyMessage (string Id, string Operation, int Value);
 
 // create a worker type with the minimum implementation 
 class MyWorker : IWorker<MyMessage> {
-    // Workers will be scheduled by the default TaskScheduler from dotnet
+    
+    // Workers will be by default considered to be IO bound unless specified otherwise
+    public bool UseBackgroundThread => false;
+
     public Task ConsumeAsync (MyMessage message, CancellationToken cancellationToken = default)
        => Task.FromResult (Completion.TrySetResult(true));
 }
 
 // creeate an error worker to handle exceptions from workers
 class ErrorWorker : IErrorWorker<MyMessage> {
+    public bool UseBackgroundThread => false;
+    
     public Task ConsumeAsync (MyMessage message, Exception exception, CancellationToken cancellationToken = default)
         => Task.FromResult (Completion.TrySetResult(true));
 }

--- a/src/Marille.Tests/CancellationTests.cs
+++ b/src/Marille.Tests/CancellationTests.cs
@@ -1,3 +1,5 @@
+using Marille.Tests.Workers;
+
 namespace Marille.Tests;
 
 public class CancellationTests : IDisposable {

--- a/src/Marille.Tests/ErrorHandlingTests.cs
+++ b/src/Marille.Tests/ErrorHandlingTests.cs
@@ -1,3 +1,5 @@
+using Marille.Tests.Workers;
+
 namespace Marille.Tests;
 
 public class ErrorHandlingTests : IDisposable {
@@ -40,7 +42,7 @@ public class ErrorHandlingTests : IDisposable {
 		// assert the id of the message and the exception
 		Assert.Equal ("2", _errorWorker.ConsumedMessages[0].Message.Id);
 		Assert.Equal (typeof(InvalidOperationException), 
-			_errorWorker.ConsumedMessages[0].Exception.InnerException!.GetType ());
+			_errorWorker.ConsumedMessages[0].Exception.GetType ());
 	}
 	
 	[Fact]
@@ -76,6 +78,6 @@ public class ErrorHandlingTests : IDisposable {
 		// assert the id of the message and the exception
 		Assert.Equal ("2", messageId);
 		Assert.Equal (typeof(InvalidOperationException), 
-			exception?.InnerException!.GetType ());
+			exception!.GetType ());
 	}
 }

--- a/src/Marille.Tests/RegistrationTests.cs
+++ b/src/Marille.Tests/RegistrationTests.cs
@@ -1,3 +1,5 @@
+using Marille.Tests.Workers;
+
 namespace Marille.Tests;
 
 public class RegistrationTests : IDisposable {

--- a/src/Marille.Tests/TopicTests.cs
+++ b/src/Marille.Tests/TopicTests.cs
@@ -1,3 +1,5 @@
+using Marille.Tests.Workers;
+
 namespace Marille.Tests;
 
 public class TopicTests : IDisposable {

--- a/src/Marille.Tests/WorkQueuesTests.cs
+++ b/src/Marille.Tests/WorkQueuesTests.cs
@@ -1,3 +1,5 @@
+using Marille.Tests.Workers;
+
 namespace Marille.Tests;
 
 // Set of tests that focus on the pattern in which a 

--- a/src/Marille.Tests/Workers/BackgroundThreadWorker.cs
+++ b/src/Marille.Tests/Workers/BackgroundThreadWorker.cs
@@ -1,0 +1,25 @@
+namespace Marille.Tests.Workers;
+
+public class BackgroundThreadWorker : IWorker<WorkQueuesEvent> {
+
+	public string Id { get; set; } = string.Empty;
+	
+	public TaskCompletionSource<bool> Completion { get; private set; }
+
+	public BackgroundThreadWorker (string id, TaskCompletionSource<bool> tcs)
+	{
+		Id = id;
+		Completion = tcs;
+	}
+	
+	public bool UseBackgroundThread => true;
+	public async Task ConsumeAsync (WorkQueuesEvent message, CancellationToken token = default)
+	{
+		await Task.Delay (TimeSpan.FromMilliseconds (1000));
+		Completion.TrySetResult (true);
+	}
+	
+	public void Dispose () { }
+
+	public ValueTask DisposeAsync () => ValueTask.CompletedTask;
+}

--- a/src/Marille.Tests/Workers/BlockingWorker.cs
+++ b/src/Marille.Tests/Workers/BlockingWorker.cs
@@ -1,3 +1,5 @@
+using Marille.Tests.Workers;
+
 namespace Marille.Tests;
 
 // this worked will block not consume events until the task completion source is triggered, this way
@@ -7,6 +9,7 @@ public class BlockingWorker (TaskCompletionSource<bool> readyToConsume) : IWorke
 	public int ConsumedCount => consumed;
 	public TaskCompletionSource<bool> ReadyToConsume { get; private set; } = readyToConsume;
 
+	public bool UseBackgroundThread => false;
 	public async Task ConsumeAsync (WorkQueuesEvent message, CancellationToken token = default)
 	{
 		// use this as a way to block the worker

--- a/src/Marille.Tests/Workers/ErrorWorker.cs
+++ b/src/Marille.Tests/Workers/ErrorWorker.cs
@@ -1,4 +1,4 @@
-namespace Marille.Tests;
+namespace Marille.Tests.Workers;
 
 public class ErrorWorker<T> : IErrorWorker<T> where T :  struct {
 
@@ -15,7 +15,9 @@ public class ErrorWorker<T> : IErrorWorker<T> where T :  struct {
 	{
 		TaskCompletionSource = tcs;
 	}
-	
+
+	public bool UseBackgroundThread => false;
+
 	public async Task ConsumeAsync (T message, Exception exception, CancellationToken token = default)
 	{
 		await _semaphoreSlim.WaitAsync ();

--- a/src/Marille.Tests/Workers/FastWorker.cs
+++ b/src/Marille.Tests/Workers/FastWorker.cs
@@ -1,4 +1,4 @@
-namespace Marille.Tests;
+namespace Marille.Tests.Workers;
 
 public struct WorkQueuesEvent {
 
@@ -24,6 +24,7 @@ public class FastWorker : IWorker<WorkQueuesEvent> {
 		Completion = tcs;
 	}
 
+	public bool UseBackgroundThread => false;
 	public Task ConsumeAsync (WorkQueuesEvent message, CancellationToken cancellationToken = default)
 		=> message.IsError ? 
 			Task.FromException (new InvalidOperationException($"Message with Id {message.Id} is an error")) :

--- a/src/Marille.Tests/Workers/SleepyWorker.cs
+++ b/src/Marille.Tests/Workers/SleepyWorker.cs
@@ -1,4 +1,4 @@
-namespace Marille.Tests;
+namespace Marille.Tests.Workers;
 
 public class SleepyWorker : IWorker<WorkQueuesEvent> {
 	Random random = new Random ();
@@ -10,6 +10,8 @@ public class SleepyWorker : IWorker<WorkQueuesEvent> {
 		Id = id;
 		Completion = tcs;
 	}
+
+	public bool UseBackgroundThread => false;
 
 	public async Task ConsumeAsync (WorkQueuesEvent message, CancellationToken cancellationToken = default)
 	{

--- a/src/Marille/IErrorWorker.cs
+++ b/src/Marille/IErrorWorker.cs
@@ -2,5 +2,7 @@ namespace Marille;
 
 public interface IErrorWorker<in T> : IDisposable, IAsyncDisposable where T : struct {
 
+	public bool UseBackgroundThread { get; }
+
 	public Task ConsumeAsync (T message, Exception exception, CancellationToken token = default);
 }

--- a/src/Marille/IWorker.cs
+++ b/src/Marille/IWorker.cs
@@ -7,6 +7,12 @@ namespace Marille;
 public interface IWorker<in T> : IDisposable, IAsyncDisposable where T :  struct {
 
 	/// <summary>
+	/// Specifies if the worker should use a background thread to process the messages. If set to
+	/// true the implementation of the worker should be thread safe.
+	/// </summary>
+	public bool UseBackgroundThread { get; }
+
+	/// <summary>
 	/// Method that will be executed for every event in the channel that has been assigned
 	/// to the worker instance.
 	/// </summary>

--- a/src/Marille/LambdaErrorWorker.cs
+++ b/src/Marille/LambdaErrorWorker.cs
@@ -1,6 +1,9 @@
 namespace Marille;
 
-internal class LambdaErrorWorker<T> (Func<T, Exception, CancellationToken, Task> lambda) : IErrorWorker<T> where T : struct {
+internal class LambdaErrorWorker<T> (Func<T, Exception, CancellationToken, Task> lambda, 
+	bool useBackgroundThread = false) : IErrorWorker<T> where T : struct {
+	
+	public bool UseBackgroundThread { get; } = useBackgroundThread;
 	public Task ConsumeAsync (T message, Exception exception, CancellationToken cancellationToken = default)
 		=> lambda (message, exception, cancellationToken);
 

--- a/src/Marille/LambdaWorker.cs
+++ b/src/Marille/LambdaWorker.cs
@@ -1,6 +1,9 @@
 namespace Marille;
 
-internal class LambdaWorker<T> (Func<T, CancellationToken,Task> lambda) : IWorker<T> where T : struct {
+internal class LambdaWorker<T> (Func<T, CancellationToken,Task> lambda, bool useBackgroundThread = false) 
+	: IWorker<T> where T : struct {
+	public bool UseBackgroundThread { get; } = useBackgroundThread;
+
 	public async Task ConsumeAsync (T message, CancellationToken cancellationToken = default)
 	{
 		// await the lambda function so that we can wrap any exceptions in a Task

--- a/src/Marille/TopicInfo.cs
+++ b/src/Marille/TopicInfo.cs
@@ -66,7 +66,7 @@ internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<
 	{
 		Channel.Writer.TryComplete ();
 		if (ConsumerTask is not null) 
-			await ConsumerTask;
+			await ConsumerTask.ConfigureAwait (false);
 	}
 
 	#region IDisposable Support


### PR DESCRIPTION
Rather than just dealing with IO bound workers we are opening the door to CPU intensive workers.

The new API allows the developer to let the hub know if the worker callback should be executed in a background task or not. This allow users to make the decision to use or no the main thread used by the hub.

There is not need to move the Consuming methods out of the main thread because those are IO bound by definition (readin gfrom a channel is IO bound). The only code that should be executed in a diff thread is that of the consumer.