### PR TITLE
[API] Provide a way to notify the IWorkers that a channel has been closed.

### DIFF
--- a/src/Marille.Tests/CancellationTests.cs
+++ b/src/Marille.Tests/CancellationTests.cs
@@ -36,6 +36,7 @@ public class CancellationTests : IDisposable {
 		// publish no messages, just close the worker
 		await _hub.CloseAsync<WorkQueuesEvent> (topic);
 		Assert.Equal (0, worker.ConsumedCount);
+		Assert.True (await worker.OnChannelClose.Task);
 		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 	
@@ -57,6 +58,7 @@ public class CancellationTests : IDisposable {
 		// publish no messages, just close the worker
 		await _hub.CloseAsync<WorkQueuesEvent> (topic);
 		Assert.NotEqual (0, worker.ConsumedCount);
+		Assert.True (await worker.OnChannelClose.Task);
 		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 
@@ -87,8 +89,11 @@ public class CancellationTests : IDisposable {
 
 		// publish no messages, just close the worker
 		await _hub.CloseAsync<WorkQueuesEvent> (topic1);
+		await _hub.CloseAsync<WorkQueuesEvent> (topic2);
 		Assert.NotEqual (0, worker1.ConsumedCount);
+		Assert.True (await worker1.OnChannelClose.Task);
 		Assert.NotEqual (0, worker2.ConsumedCount);
+		Assert.True (await worker2.OnChannelClose.Task);
 		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 	
@@ -113,8 +118,11 @@ public class CancellationTests : IDisposable {
 
 		// publish no messages, just close the worker
 		await _hub.CloseAsync<WorkQueuesEvent> (topic1);
+		await _hub.CloseAsync<WorkQueuesEvent> (topic2);
 		Assert.Equal (0, worker1.ConsumedCount);
+		Assert.True (await worker1.OnChannelClose.Task);
 		Assert.Equal (0, worker2.ConsumedCount);
+		Assert.True (await worker2.OnChannelClose.Task);
 		Assert.Equal (0, _errorWorker.ConsumedCount);
 	}
 

--- a/src/Marille.Tests/Workers/BackgroundThreadWorker.cs
+++ b/src/Marille.Tests/Workers/BackgroundThreadWorker.cs
@@ -18,7 +18,9 @@ public class BackgroundThreadWorker : IWorker<WorkQueuesEvent> {
 		await Task.Delay (TimeSpan.FromMilliseconds (1000));
 		Completion.TrySetResult (true);
 	}
-	
+
+	public Task OnChannelClosedAsync (string channelName, CancellationToken token = default) => Task.CompletedTask; 
+
 	public void Dispose () { }
 
 	public ValueTask DisposeAsync () => ValueTask.CompletedTask;

--- a/src/Marille.Tests/Workers/FastWorker.cs
+++ b/src/Marille.Tests/Workers/FastWorker.cs
@@ -30,6 +30,8 @@ public class FastWorker : IWorker<WorkQueuesEvent> {
 			Task.FromException (new InvalidOperationException($"Message with Id {message.Id} is an error")) :
 			Task.FromResult (Completion.TrySetResult(true));
 
+	public Task OnChannelClosedAsync (string channelName, CancellationToken token = default) => Task.CompletedTask; 
+
 	public void Dispose () { }
 
 	public ValueTask DisposeAsync () => ValueTask.CompletedTask;

--- a/src/Marille.Tests/Workers/SleepyWorker.cs
+++ b/src/Marille.Tests/Workers/SleepyWorker.cs
@@ -20,6 +20,8 @@ public class SleepyWorker : IWorker<WorkQueuesEvent> {
 		Completion.TrySetResult (true);
 	}
 
+	public Task OnChannelClosedAsync (string channelName, CancellationToken token = default) => Task.CompletedTask; 
+
 	public void Dispose () { }
 
 	public ValueTask DisposeAsync () => ValueTask.CompletedTask;

--- a/src/Marille/IWorker.cs
+++ b/src/Marille/IWorker.cs
@@ -18,6 +18,14 @@ public interface IWorker<in T> : IDisposable, IAsyncDisposable where T :  struct
 	/// </summary>
 	/// <param name="message">The messages from the channel assigned to be processed by the worker instance.</param>
 	/// <param name="token">Calculation toke provided to the worker. This cancellation token should be respected.</param>
-	/// <returns></returns>
+	/// <returns>The task to be awaited.</returns>
 	public Task ConsumeAsync (T message, CancellationToken token = default);
+
+	/// <summary>
+	/// Method to be executed when the channel has been closed. This allows the worker to perform any cleanup.
+	/// </summary>
+	/// <param name="channelName">The channel name that has been closed.</param>
+	/// <param name="token">Calculation toke provided to the worker. This cancellation token should be respected.</param>
+	/// <returns>The task to be awaited.</returns>
+	public Task OnChannelClosedAsync (string channelName, CancellationToken token = default);
 }

--- a/src/Marille/LambdaWorker.cs
+++ b/src/Marille/LambdaWorker.cs
@@ -10,6 +10,8 @@ internal class LambdaWorker<T> (Func<T, CancellationToken,Task> lambda, bool use
 		await lambda (message, cancellationToken);
 	}
 
+	public Task OnChannelClosedAsync (string channelName, CancellationToken token = default) => Task.CompletedTask; 
+
 	public void Dispose () { }
 
 	public ValueTask DisposeAsync () => ValueTask.CompletedTask;

--- a/src/Marille/Marille.csproj
+++ b/src/Marille/Marille.csproj
@@ -18,7 +18,7 @@
     <PropertyGroup>
         <Title>Marille</Title>
         <PackageId>Marille</PackageId>
-        <Version>0.5.3</Version>
+        <Version>0.5.4</Version>
         <Authors>Manuel de la Peña Saenz</Authors>
         <Owners>Manuel de la Peña Saenz</Owners>
         <Copyright>Manuel de la Peña Saenz</Copyright>

--- a/src/Marille/Topic.cs
+++ b/src/Marille/Topic.cs
@@ -32,7 +32,7 @@ internal class Topic (string name) : IDisposable, IAsyncDisposable {
 			var ch = (configuration.Capacity is null) ? 
 				Channel.CreateUnbounded<Message<T>> () : 
 				Channel.CreateBounded<Message<T>> (configuration.Capacity.Value);
-			topicInfo = new(configuration, ch, errorWorker, workers);
+			topicInfo = new(Name, configuration, ch, errorWorker, workers);
 			channels[type] = topicInfo;
 			return true;
 		}

--- a/src/Marille/TopicInfo.cs
+++ b/src/Marille/TopicInfo.cs
@@ -2,7 +2,7 @@ using System.Threading.Channels;
 
 namespace Marille;
 
-internal abstract record TopicInfo (TopicConfiguration Configuration) : IDisposable, IAsyncDisposable {
+internal abstract record TopicInfo (string TopicName, TopicConfiguration Configuration) : IDisposable, IAsyncDisposable {
 	public CancellationTokenSource? CancellationTokenSource { get; set;  }
 	public Task? ConsumerTask { get; set; }
 
@@ -50,13 +50,13 @@ internal abstract record TopicInfo (TopicConfiguration Configuration) : IDisposa
 	#endregion
 }
 
-internal record TopicInfo<T> (TopicConfiguration Configuration, Channel<Message<T>> Channel, IErrorWorker<T> ErrorWorker) 
-	: TopicInfo (Configuration) where T : struct {
+internal record TopicInfo<T> (string TopicName, TopicConfiguration Configuration, Channel<Message<T>> Channel, IErrorWorker<T> ErrorWorker) 
+	: TopicInfo (TopicName, Configuration) where T : struct {
 
 	public List<IWorker<T>> Workers { get; } = new();
 
-	public TopicInfo (TopicConfiguration configuration, Channel<Message<T>> channel, IErrorWorker<T> errorWorker,
-		params IWorker<T> [] workers) : this(configuration, channel, errorWorker)
+	public TopicInfo (string topicName, TopicConfiguration configuration, Channel<Message<T>> channel, IErrorWorker<T> errorWorker,
+		params IWorker<T> [] workers) : this(topicName, configuration, channel, errorWorker)
 	{
 		ErrorWorker = errorWorker;
 		Workers.AddRange (workers);


### PR DESCRIPTION


It might be the case that the IWorkers are storing state data realted to a topic, therefore we need a way from the IWorkers to know that the channel has been closed and that no more messages are going to be received.