### PR TITLE
[API] Default implementation for IWorker.UseBackgroundThread.

### DIFF
--- a/src/Marille/IWorker.cs
+++ b/src/Marille/IWorker.cs
@@ -9,8 +9,10 @@ public interface IWorker<in T> : IDisposable, IAsyncDisposable where T :  struct
 	/// <summary>
 	/// Specifies if the worker should use a background thread to process the messages. If set to
 	/// true the implementation of the worker should be thread safe.
+	///
+	/// The default implementation returns false.
 	/// </summary>
-	public bool UseBackgroundThread { get; }
+	public bool UseBackgroundThread { get => false; }
 
 	/// <summary>
 	/// Method that will be executed for every event in the channel that has been assigned


### PR DESCRIPTION
Add a default property implementation for the propery so that users do not have to constantly implement it. This allow developers to ignore the implementation unless thye do want to use a backgrond thread.