### PR TITLE
[Internal API] Protect against properties that throw exceptions.

### DIFF
--- a/src/Marille/Hub.cs
+++ b/src/Marille/Hub.cs
@@ -63,7 +63,8 @@ public class Hub : IHub {
 		var tasks = new Task [workersArray.Length];
 		for(var index = 0; index < workersArray.Length; index++) {
 			var worker = workersArray [index];
-			if (worker.UseBackgroundThread) {
+			_ = worker.TryGetUseBackgroundThread (out var useBackgroundThread);
+			if (useBackgroundThread) {
 				tasks [index] = Task.Run (async () => {
 					await worker.ConsumeAsync (item.Payload, token).ConfigureAwait (false);
 				}, token);
@@ -88,7 +89,8 @@ public class Hub : IHub {
 			token = cts.Token;
 		}
 
-		var task = worker.UseBackgroundThread ? 
+		_ = worker.TryGetUseBackgroundThread (out var useBackgroundThread);
+		var task = useBackgroundThread ? 
 			Task.Run (async () => { 
 				await worker.ConsumeAsync (item.Payload, token).ConfigureAwait (false);
 			}, token) :

--- a/src/Marille/WorkerExtensions.cs
+++ b/src/Marille/WorkerExtensions.cs
@@ -1,0 +1,17 @@
+namespace Marille; 
+
+internal static class WorkerExtensions {
+
+	// properties can throw (ie: NotImplementedException) so we need to catch them and use a default value. We should
+	// allow to log this later.
+	public static bool TryGetUseBackgroundThread<T> (this IWorker<T> worker, out bool useBackgroundThread) where T : struct
+	{
+		useBackgroundThread = false;
+		try {
+			useBackgroundThread = worker.UseBackgroundThread;
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
Allow the hub to be able to handle IWorker interface implementations that throw exceptions in the UseBackgroundThread property.

Sometimes it would be nice to have the cocept that java has with the 'throws' keyword :/