### PR TITLE
[Actions] Reuse the deploy docs workflow.

### DIFF
--- a/.github/workflows/auto_deploy_docs.yml
+++ b/.github/workflows/auto_deploy_docs.yml
@@ -1,0 +1,22 @@
+# yamllint disable rule:line-length
+# deployes the build to nuget and github releases
+name: Deploy docs on docs/* updates
+
+concurrency:
+  group: "deployment"
+  cancel-in-progress: false
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  actions: read
+  pages: write
+  id-token: write
+
+on:
+  push:
+    paths:
+      - docs/*
+
+jobs:
+  publish-docs:
+    uses: ./.github/workflows/deploy_docs_job.yml

--- a/.github/workflows/auto_deploy_docs.yml
+++ b/.github/workflows/auto_deploy_docs.yml
@@ -1,6 +1,6 @@
 # yamllint disable rule:line-length
 # deployes the build to nuget and github releases
-name: Deploy docs on docs/* updates
+name: Auto deploy docs
 
 concurrency:
   group: "deployment"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,36 +57,7 @@ jobs:
           path: ${{ env.NuGetDirectory }}/*.nupkg
 
   publish-docs:
-    name: Publish docs
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-
-      - name: Install Docfx
-        run: dotnet tool update -g docfx
-
-      - name: Run Docfx
-        run: docfx docs/docfx.json
-
-      - name: Upload docs page 
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'docs/_site'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    uses: ./.github/workflows/deploy_docs_job.yml
 
   validate-nuget:
     name: Validate nuget


### PR DESCRIPTION
Use the reusable workflow in two actions:
- When we deploy a new nuget version, deploy the docs too.
- When we update any path unders docs, deploy the docs.