### PR TITLE
[Bug] Ensure that CloseAsync completes and that the tests do not block.

### DIFF
--- a/src/Marille.Tests/BaseTimeoutTest.cs
+++ b/src/Marille.Tests/BaseTimeoutTest.cs
@@ -1,0 +1,18 @@
+namespace Marille.Tests; 
+
+// base test class that will create a cancellation token for the unit tests
+// to use
+public class BaseTimeoutTest {
+	private readonly int _timeout;
+	protected BaseTimeoutTest (int milliseconds)
+	{
+		_timeout = milliseconds;
+	}
+
+	protected CancellationTokenSource GetCancellationToken ()
+	{
+		var cts = new CancellationTokenSource ();
+		cts.CancelAfter (_timeout);
+		return cts;
+	}
+}

--- a/src/Marille.Tests/RegistrationTests.cs
+++ b/src/Marille.Tests/RegistrationTests.cs
@@ -2,12 +2,12 @@ using Marille.Tests.Workers;
 
 namespace Marille.Tests;
 
-public class RegistrationTests : IDisposable {
+public class RegistrationTests : BaseTimeoutTest, IDisposable {
 	readonly Hub _hub;
 	readonly ErrorWorker<WorkQueuesEvent> _errorWorker;
 	readonly SemaphoreSlim _semaphoreSlim;
 
-	public RegistrationTests ()
+	public RegistrationTests () : base(milliseconds:1000)
 	{
 		_semaphoreSlim = new(1);
 		_hub = new (_semaphoreSlim);
@@ -24,67 +24,73 @@ public class RegistrationTests : IDisposable {
 	[Fact]
 	public async Task SingleOneToOneCreation ()
 	{
+		using var cts = GetCancellationToken ();
 		const string topic = nameof (SingleOneToOneCreation); 
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new FastWorker ("myWorkerID", tcs);
 		var workers = new [] { worker };
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		Assert.True (await _hub.CreateAsync (topic, configuration, _errorWorker, workers));
+		Assert.True (await _hub.CreateAsync (topic, configuration, _errorWorker, workers).WaitAsync (cts.Token));
 	}
 
 	[Fact]
 	public async Task MultipleOneToOneCreation ()
 	{
+		using var cts = GetCancellationToken ();
 		var topic = nameof (MultipleOneToOneCreation);
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker1 = new FastWorker ("myWorkerID", tcs);
 		var worker2 = new FastWorker ("myWorkerID", tcs);
 		var workers = new [] { worker1, worker2 };
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		Assert.False(await _hub.CreateAsync (topic, configuration, _errorWorker, workers));
+		Assert.False(await _hub.CreateAsync (topic, configuration, _errorWorker, workers).WaitAsync (cts.Token));
 	}
 
 	[Fact]
 	public async Task SingleOneToOneRegistration ()
 	{
+		using var cts = GetCancellationToken ();
 		var topic = nameof (SingleOneToOneRegistration);
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker = new FastWorker ("myWorkerID", tcs);
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		await _hub.CreateAsync (topic, configuration, _errorWorker);
-		Assert.True (await _hub.RegisterAsync (topic, worker));
+		await _hub.CreateAsync (topic, configuration, _errorWorker).WaitAsync (cts.Token);
+		Assert.True (await _hub.RegisterAsync (topic, worker).WaitAsync (cts.Token));
 	}
 
 	[Fact]
 	public async Task MultipleOneToOneRegistration ()
 	{
+		using var cts = GetCancellationToken ();
 		var topic = nameof (MultipleOneToOneRegistration);
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker1 = new FastWorker ("myWorkerID", tcs);
 		var worker2 = new FastWorker ("myWorkerID", tcs);
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		await _hub.CreateAsync (topic, configuration, _errorWorker);
-		Assert.True (await _hub.RegisterAsync (topic, worker1));
-		Assert.False(await _hub.RegisterAsync (topic, worker2));
+		await _hub.CreateAsync (topic, configuration, _errorWorker).WaitAsync (cts.Token);
+		Assert.True (await _hub.RegisterAsync (topic, worker1).WaitAsync (cts.Token));
+		Assert.False(await _hub.RegisterAsync (topic, worker2).WaitAsync (cts.Token));
 	}
 
 	[Fact]
 	public async Task MultipleOneToOneRegistrationWithLambda ()
 	{
+		using var cts = GetCancellationToken ();
 		var topic = nameof (MultipleOneToOneRegistrationWithLambda);
 		var tcs = new TaskCompletionSource<bool> ();
 		var worker1 = new FastWorker ("myWorkerID", tcs);
 		Func<WorkQueuesEvent, CancellationToken, Task> action = (_, _) =>
 			Task.FromResult (tcs.TrySetResult(true));
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
-		await _hub.CreateAsync (topic, configuration, _errorWorker);
-		Assert.True (await _hub.RegisterAsync (topic, worker1));
-		Assert.False(await _hub.RegisterAsync (topic, action));
+		await _hub.CreateAsync (topic, configuration, _errorWorker).WaitAsync (cts.Token);
+		Assert.True (await _hub.RegisterAsync (topic, worker1).WaitAsync (cts.Token));
+		Assert.False(await _hub.RegisterAsync (topic, action).WaitAsync (cts.Token));
 	}
 
 	[Fact]
 	public async Task MutithreadCreate ()
 	{
+		using var cts = GetCancellationToken ();
 		var threadCount = 100;
 		var results = new List<Task<bool>> (100);
 
@@ -93,7 +99,7 @@ public class RegistrationTests : IDisposable {
 
 		TopicConfiguration configuration = new() { Mode = ChannelDeliveryMode.AtMostOnceAsync };
 
-		await _semaphoreSlim.WaitAsync ();
+		await _semaphoreSlim.WaitAsync (cts.Token);
 		for (var index = 0; index < threadCount; index++) {
 			var tcs = new TaskCompletionSource<bool> ();
 			results.Add (tcs.Task);
@@ -104,9 +110,9 @@ public class RegistrationTests : IDisposable {
 			Task.Run (async () => {
 #pragma warning restore CS4014
 				// random sleep to ensure that the other thread is also trying to create
-				var sleep = random.Next (1000);
-				await Task.Delay (TimeSpan.FromMilliseconds (sleep));
-				var created = await _hub.CreateAsync (topic, configuration, _errorWorker);
+				var sleep = random.Next (100);
+				await Task.Delay (TimeSpan.FromMilliseconds (sleep), cts.Token);
+				var created = await _hub.CreateAsync (topic, configuration, _errorWorker).WaitAsync (cts.Token);
 				tcs.TrySetResult (created);
 			});
 		}

--- a/src/Marille.Tests/TopicTests.cs
+++ b/src/Marille.Tests/TopicTests.cs
@@ -45,18 +45,18 @@ public class TopicTests : IDisposable {
 	}
 	
 	[Fact]
-	public async Task RemoveOnlyChannel ()
+	public void RemoveOnlyChannel ()
 	{
 		// remove the channel and ensure that it will be empty
 		var errorWorker = new ErrorWorker<int> ();
 		Assert.True (_topic.TryCreateChannel (_configuration, out _, errorWorker));
 		Assert.Equal (1, _topic.ChannelCount);
-		await _topic.RemoveChannel<int> ();
+		_topic.RemoveChannel<int> ();
 		Assert.Equal (0, _topic.ChannelCount);
 	}
 	
 	[Fact]
-	public async Task RemoveWithSeveralChannels ()
+	public void RemoveWithSeveralChannels ()
 	{
 		// ensure that only once channel will be removed
 		var errorWorker = new ErrorWorker<int> ();
@@ -64,7 +64,7 @@ public class TopicTests : IDisposable {
 		Assert.True (_topic.TryCreateChannel (_configuration, out _, errorWorker));
 		Assert.True (_topic.TryCreateChannel (_configuration, out _, errorWorker2));
 		Assert.Equal (2, _topic.ChannelCount);
-		await _topic.RemoveChannel<int> ();
+		_topic.RemoveChannel<int> ();
 		Assert.Equal (1, _topic.ChannelCount);
 	}
 	

--- a/src/Marille.Tests/Workers/BlockingWorker.cs
+++ b/src/Marille.Tests/Workers/BlockingWorker.cs
@@ -22,7 +22,7 @@ public class BlockingWorker (TaskCompletionSource<bool> readyToConsume) : IWorke
 	public Task OnChannelClosedAsync (string channelName, CancellationToken token = default)
 	{
 		OnChannelClose.TrySetResult (true);
-		return Task.CompletedTask;
+		return OnChannelClose.Task;
 	}
 
 	public void Dispose () { }

--- a/src/Marille/IHub.cs
+++ b/src/Marille/IHub.cs
@@ -122,18 +122,6 @@ public interface IHub : IDisposable, IAsyncDisposable {
 	/// of the messages while it adds the worker and will resume the processing after. Producer can be sending
 	/// messages while this operation takes place because messages will be buffered by the channel.</remarks>
 	public Task<bool> RegisterAsync<T> (string topicName, Func<T, CancellationToken, Task> action) where T : struct;
-	
-	/// <summary>
-	/// Allows to publish a message in a given topic. The message will be added to a channel and will be
-	/// consumed by any worker that might have been added.
-	/// </summary>
-	/// <param name="topicName">The topic name that will deliver messages to the worker.</param>
-	/// <param name="publishedEvent">The message to be publish in the topic.</param>
-	/// <typeparam name="T">The type of messages of the topic.</typeparam>
-	/// <returns>true of the message was delivered to the topic.</returns>
-	/// <exception cref="InvalidOperationException">Thrown if no topic can be found with the provided
-	/// (topicName, messageType) combination.</exception>
-	public ValueTask PublishAsync<T> (string topicName, T publishedEvent) where T : struct;
 
 	/// <summary>
 	/// Allows to publish a message in a given topic. The message will be added to a channel and will be
@@ -141,11 +129,27 @@ public interface IHub : IDisposable, IAsyncDisposable {
 	/// </summary>
 	/// <param name="topicName">The topic name that will deliver messages to the worker.</param>
 	/// <param name="publishedEvent">The message to be publish in the topic.</param>
+	/// <param name="cancellationToken"></param>
 	/// <typeparam name="T">The type of messages of the topic.</typeparam>
 	/// <returns>true of the message was delivered to the topic.</returns>
 	/// <exception cref="InvalidOperationException">Thrown if no topic can be found with the provided
 	/// (topicName, messageType) combination.</exception>
-	public ValueTask PublishAsync<T> (string topicName, T? publishedEvent) where T : struct;
+	public ValueTask PublishAsync<T> (string topicName, T publishedEvent, 
+		CancellationToken cancellationToken = default) where T : struct;
+
+	/// <summary>
+	/// Allows to publish a message in a given topic. The message will be added to a channel and will be
+	/// consumed by any worker that might have been added.
+	/// </summary>
+	/// <param name="topicName">The topic name that will deliver messages to the worker.</param>
+	/// <param name="publishedEvent">The message to be publish in the topic.</param>
+	/// <param name="cancellationToken"></param>
+	/// <typeparam name="T">The type of messages of the topic.</typeparam>
+	/// <returns>true of the message was delivered to the topic.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if no topic can be found with the provided
+	/// (topicName, messageType) combination.</exception>
+	public ValueTask PublishAsync<T> (string topicName, T? publishedEvent,
+		CancellationToken cancellationToken = default) where T : struct;
 
 	/// <summary>
 	/// Allows to publish a message in the given topic. The method will fail on bounded channels depending on the
@@ -176,15 +180,17 @@ public interface IHub : IDisposable, IAsyncDisposable {
 	/// <summary>
 	/// Cancel all channels in the Hub and return a task that will be completed once all the channels have been flushed.
 	/// </summary>
+	/// <param name="cancellationToken"></param>
 	/// <returns>A task that will be completed once ALL the channels have been flushed.</returns>
-	public Task CloseAllAsync ();
+	public Task CloseAllAsync (CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Cancels the channel in the Hub with the given token and returns a task that will be completed once the channel
 	/// has been flushed. 
 	/// </summary>
 	/// <param name="topicName">The name of the topic to cancel.</param>
+	/// <param name="cancellationToken"></param>
 	/// <typeparam name="T">The type of events of the topic.</typeparam>
 	/// <returns>A task that will be completed once the channel has been flushed.</returns>
-	public Task<bool> CloseAsync<T> (string topicName) where T : struct;
+	public Task<bool> CloseAsync<T> (string topicName, CancellationToken cancellationToken = default) where T : struct;
 }

--- a/src/Marille/Topic.cs
+++ b/src/Marille/Topic.cs
@@ -40,13 +40,13 @@ internal class Topic (string name) : IDisposable, IAsyncDisposable {
 		return false;
 	}
 
-	public async Task RemoveChannel<T> () where T : struct
+	public TopicInfo<T>? RemoveChannel<T> () where T : struct
 	{
 		if (!TryGetChannel<T> (out var topicInfo))
-			return;
+			return null;
 
-		await topicInfo.DisposeAsync ();
 		channels.Remove (typeof (T));
+		return topicInfo;
 	}
 
 	#region IDisposable Support


### PR DESCRIPTION
The CloseAsync method had a bug due to a race condition between the way the Dispose pattern could be executing making the tests hang. We have done the following:

1. Fix the issue with the CloseAsync.
2. Change all the tests to have a timeout so that even if we have a bug we do complete the tests.