### PR TITLE
[API] Implement the error retry logic.

### DIFF
--- a/src/Marille.Tests/MessageTests.cs
+++ b/src/Marille.Tests/MessageTests.cs
@@ -1,0 +1,38 @@
+namespace Marille.Tests; 
+
+public class MessageTests {
+	
+	[Fact]
+	public void CreateMessageTest ()
+	{
+		var message = new Message<int> (MessageType.Data, 42, 0);
+		Assert.Equal (MessageType.Data, message.Type);
+		Assert.Equal (42, message.Payload);
+		Assert.Equal (0, message.Retries);
+		Assert.False (message.IsError);
+		Assert.Null (message.Exception);
+	}
+	
+	[Fact]
+	public void CreateErrorMessageTest ()
+	{
+		var exception = new InvalidOperationException ("Test");
+		var message = new Message<int> (42, exception);
+		Assert.Equal (MessageType.Error, message.Type);
+		Assert.Equal (42, message.Payload);
+		Assert.Equal (0, message.Retries);
+		Assert.True (message.IsError);
+		Assert.Equal (exception, message.Exception);
+	}
+	
+	[Fact]
+	public void CreateMessageWithRetriesTest ()
+	{
+		var message = new Message<int> (MessageType.Data, 42, 5);
+		Assert.Equal (MessageType.Data, message.Type);
+		Assert.Equal (42, message.Payload);
+		Assert.Equal (5, message.Retries);
+		Assert.False (message.IsError);
+		Assert.Null (message.Exception);
+	}
+}

--- a/src/Marille.Tests/TopicConfigurationTests.cs
+++ b/src/Marille.Tests/TopicConfigurationTests.cs
@@ -1,0 +1,29 @@
+namespace Marille.Tests; 
+
+public class TopicConfigurationTests {
+	
+	[Fact]
+	public void CreateTopicConfigurationTest ()
+	{
+		var configuration = new TopicConfiguration();
+		Assert.Equal (ChannelDeliveryMode.AtLeastOnceAsync, configuration.Mode);
+		Assert.Null (configuration.MaxRetries);
+		Assert.Null (configuration.MaxCapacity);
+		Assert.Null (configuration.Timeout);
+	}
+	
+	[Fact]
+	public void CreateTopicConfigurationWithValuesTest ()
+	{
+		var configuration = new TopicConfiguration() {
+			Mode = ChannelDeliveryMode.AtMostOnceAsync,
+			MaxRetries = 5,
+			MaxCapacity = 10,
+			Timeout = TimeSpan.FromSeconds(5)
+		};
+		Assert.Equal (ChannelDeliveryMode.AtMostOnceAsync, configuration.Mode);
+		Assert.Equal (5u, configuration.MaxRetries);
+		Assert.Equal (10, configuration.MaxCapacity);
+		Assert.Equal (TimeSpan.FromSeconds(5), configuration.Timeout);
+	}
+}

--- a/src/Marille/Message.cs
+++ b/src/Marille/Message.cs
@@ -15,19 +15,21 @@ internal struct Message<T> where T : struct {
 	public bool IsError => Type == MessageType.Error;
 	public T Payload { get; }
 	public Exception? Exception { get; }
-
+	public int Retries = 0;
+	
 	public Message (MessageType type)
 	{
 		Id = Guid.NewGuid();
 		Type = type;
 		Payload = default;
 	}
-	public Message (MessageType type, T payload) : this(type)
+	public Message (MessageType type, T payload, uint? retries) : this(type)
 	{
 		Id = Guid.NewGuid();
 		Payload = payload;
+		Retries = (int) (retries ?? 0);
 	}
-	public Message (T payload, Exception exception) : this(MessageType.Error, payload)
+	public Message (T payload, Exception exception) : this(MessageType.Error, payload, null)
 	{
 		Exception = exception;
 	}

--- a/src/Marille/Topic.cs
+++ b/src/Marille/Topic.cs
@@ -29,9 +29,9 @@ internal class Topic (string name) : IDisposable, IAsyncDisposable {
 	{
 		Type type = typeof (T);
 		if (!TryGetChannel (out topicInfo)) {
-			var ch = (configuration.Capacity is null) ? 
+			var ch = (configuration.MaxCapacity is null) ? 
 				Channel.CreateUnbounded<Message<T>> () : 
-				Channel.CreateBounded<Message<T>> (configuration.Capacity.Value);
+				Channel.CreateBounded<Message<T>> (configuration.MaxCapacity.Value);
 			topicInfo = new(Name, configuration, ch, errorWorker, workers);
 			channels[type] = topicInfo;
 			return true;

--- a/src/Marille/TopicConfiguration.cs
+++ b/src/Marille/TopicConfiguration.cs
@@ -16,10 +16,15 @@ public struct TopicConfiguration () {
 	/// When no capacity (null) is provided, the channel won't have a capacity and producers will
 	/// be able to write in the channel as much as they want as long as it is opened.
 	/// </summary>
-	public int? Capacity { get; set; } = null;
+	public int? MaxCapacity { get; set; } = null;
 	
 	/// <summary>
 	/// Default timeout for the workers that consume messages in the channel. 
 	/// </summary>
 	public TimeSpan? Timeout { get; set; } = null;
+
+	/// <summary>
+	/// Max number of retries that will be performed when a worker fails to consume a message.
+	/// </summary>
+	public uint? MaxRetries { get; set; } = null;
 }


### PR DESCRIPTION
Allow channels to resend and event if it has to be retried. The message will be queued again since it is a "new Event".