### PR TITLE
[API] Implement max parallel

### DIFF
--- a/src/Marille.Tests/TopicConfigurationTests.cs
+++ b/src/Marille.Tests/TopicConfigurationTests.cs
@@ -10,6 +10,7 @@ public class TopicConfigurationTests {
 		Assert.Null (configuration.MaxRetries);
 		Assert.Null (configuration.MaxCapacity);
 		Assert.Null (configuration.Timeout);
+		Assert.Null (configuration.MaxParallelism);
 	}
 	
 	[Fact]
@@ -19,11 +20,16 @@ public class TopicConfigurationTests {
 			Mode = ChannelDeliveryMode.AtMostOnceAsync,
 			MaxRetries = 5,
 			MaxCapacity = 10,
+			MaxParallelism = 15,
 			Timeout = TimeSpan.FromSeconds(5)
 		};
 		Assert.Equal (ChannelDeliveryMode.AtMostOnceAsync, configuration.Mode);
-		Assert.Equal (5u, configuration.MaxRetries);
-		Assert.Equal (10, configuration.MaxCapacity);
+		Assert.NotNull(configuration.MaxRetries);
+		Assert.Equal (5u, configuration.MaxRetries.Value);
+		Assert.NotNull (configuration.MaxCapacity);
+		Assert.Equal (10, configuration.MaxCapacity.Value);
+		Assert.NotNull (configuration.MaxParallelism);
+		Assert.Equal (15u, configuration.MaxParallelism.Value);
 		Assert.Equal (TimeSpan.FromSeconds(5), configuration.Timeout);
 	}
 }

--- a/src/Marille/ConsumeTaskData.cs
+++ b/src/Marille/ConsumeTaskData.cs
@@ -1,0 +1,32 @@
+namespace Marille;
+
+internal readonly struct ConsumeTaskData : IDisposable, IAsyncDisposable {
+	
+	public Task? Task { get; init; } = null;
+	public SemaphoreSlim? Semaphore { get; init; } = null;
+	
+	public ConsumeTaskData () { }
+
+	public void Dispose()
+	{
+		Task?.Dispose ();
+		Semaphore?.Dispose ();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (Task is not null) await CastAndDispose (Task);
+		if (Semaphore is not null) await CastAndDispose (Semaphore);
+
+		return;
+
+		static async ValueTask CastAndDispose (IDisposable resource)
+		{
+			if (resource is IAsyncDisposable resourceAsyncDisposable)
+				await resourceAsyncDisposable.DisposeAsync ();
+			else
+				resource.Dispose ();
+		}
+	}
+
+}

--- a/src/Marille/Hub.cs
+++ b/src/Marille/Hub.cs
@@ -115,7 +115,8 @@ public class Hub : IHub {
 	}
 
 	async Task ConsumeChannel<T> (string name, TopicConfiguration configuration, Channel<Message<T>> ch, IErrorWorker<T> errorWorker, 
-		IWorker<T>[] workersArray, TaskCompletionSource<bool> completionSource, CancellationToken cancellationToken) where T : struct
+		IWorker<T>[] workersArray, TaskCompletionSource<bool> completionSource, CancellationToken cancellationToken, 
+		SemaphoreSlim? parallelSemaphore) where T : struct
 	{
 		// this is an important check, else the items will be consumer with no worker to receive them
 		if (workersArray.Length == 0) {
@@ -140,14 +141,23 @@ public class Hub : IHub {
 					// crash the whole consuming task. Sometimes java was right when adding exceptions to a method signature
 					try {
 						var _ = errorWorker.TryGetUseBackgroundThread (out var useBackgroundThread);
-						if (useBackgroundThread)
+						if (useBackgroundThread) {
+							// if we are using a thread and we want to limit the number of parallel tasks, we need to
+							// get the semaphore before we start the task, then release it when we are done
+							if (parallelSemaphore is not null)
+								await parallelSemaphore.WaitAsync (cancellationToken);
 							await Task.Run (async () => {
-								await errorWorker.ConsumeAsync (
-									item.Payload, item.Exception, cancellationToken).ConfigureAwait (false);
+								try {
+									await errorWorker.ConsumeAsync (
+										item.Payload, item.Exception, cancellationToken).ConfigureAwait (false);
+								} finally {
+									parallelSemaphore?.Release ();
+								}
 							}, cancellationToken);
-						else
+						} else {
 							await errorWorker.ConsumeAsync (
 								item.Payload, item.Exception, cancellationToken).ConfigureAwait (false);
+						}
 					} catch {
 						// should we log the exception we are ignoring?
 						logger?.LogErrorConsumerException (errorWorker.GetType (), item.Payload, item.Exception, name,
@@ -166,8 +176,17 @@ public class Hub : IHub {
 						name, ch, workersArray, item, configuration.Timeout).ConfigureAwait (false);
 					break;
 				case ChannelDeliveryMode.AtMostOnceAsync:
-					_ = Task.Run (async () => 
-						await DeliverAtMostOnceAsync (name, ch, workersArray, item, configuration.Timeout), cancellationToken);
+					// because we are using diff threads, we need to make sure that we do not consume too many resources,
+					// we grab the semaphore and release it when we are done
+					if (parallelSemaphore is not null)
+						await parallelSemaphore.WaitAsync (cancellationToken);
+					_ = Task.Run (async () => {
+						try {
+							await DeliverAtMostOnceAsync (name, ch, workersArray, item, configuration.Timeout);
+						} finally {
+							parallelSemaphore?.Release ();
+						}
+					}, cancellationToken);
 					break;
 				case ChannelDeliveryMode.AtMostOnceSync:
 					// make the call 'sync' by not processing an item until we are done with the current one
@@ -210,8 +229,16 @@ public class Hub : IHub {
 		// we have no interest in awaiting for this task, but we want to make sure it started. To do so
 		// we create a TaskCompletionSource that will be set when the consume channel method is ready to consume
 		var completionSource = new TaskCompletionSource<bool>();
-		topicInfo.ConsumerTask = ConsumeChannel (topicInfo.TopicName, topicInfo.Configuration, topicInfo.Channel, 
-			topicInfo.ErrorWorker, workersCopy, completionSource, topicInfo.CancellationTokenSource.Token);
+		// create a consumer data task that will contain the resources we need to keep track of it
+		var semaphore = (topicInfo.Configuration.MaxParallelism is not null) ? 
+			new SemaphoreSlim ((int)topicInfo.Configuration.MaxParallelism.Value) : null;
+		
+		var consumerDataTask = new ConsumeTaskData () {
+			Semaphore = semaphore,
+			Task = ConsumeChannel (topicInfo.TopicName, topicInfo.Configuration, topicInfo.Channel, 
+				topicInfo.ErrorWorker, workersCopy, completionSource, topicInfo.CancellationTokenSource.Token, semaphore)
+		};
+		topicInfo.ConsumerTask = consumerDataTask;
 		// send a message with a ack so that we can ensure we are indeed running
 		_ = topicInfo.Channel.Writer.WriteAsync (new (MessageType.Ack), topicInfo.CancellationTokenSource.Token);
 		return await completionSource.Task.ConfigureAwait (false);
@@ -437,8 +464,8 @@ public class Hub : IHub {
 				return false;
 			
 			await topicInfo.CloseChannel ().ConfigureAwait (false);
-			if (topicInfo.ConsumerTask is not null) {
-				await topicInfo.ConsumerTask;
+			if (topicInfo.ConsumerTask is not null && topicInfo.ConsumerTask?.Task is not null) {
+				await topicInfo.ConsumerTask.Value.Task;
 			}
 
 			// clean the topic if needed

--- a/src/Marille/Topic.cs
+++ b/src/Marille/Topic.cs
@@ -11,7 +11,8 @@ internal class Topic (string name) : IDisposable, IAsyncDisposable {
 
 	public IEnumerable<Task> ConsumerTasks => from info in channels.Values
 		where info.ConsumerTask is not null
-		select info.ConsumerTask;
+		where info.ConsumerTask?.Task is not null
+		select info.ConsumerTask?.Task;
 
 	public bool TryGetChannel<T> ([NotNullWhen (true)] out TopicInfo<T>? channel) where T : struct
 	{

--- a/src/Marille/TopicConfiguration.cs
+++ b/src/Marille/TopicConfiguration.cs
@@ -27,4 +27,11 @@ public struct TopicConfiguration () {
 	/// Max number of retries that will be performed when a worker fails to consume a message.
 	/// </summary>
 	public uint? MaxRetries { get; set; } = null;
+	
+	/// <summary>
+	/// Max number of parallel workers that will be able to consume messages from the channel. The default is to
+	/// queue all workers that need a background thread using the ThreadPool. This might result in overloading the
+	/// pool. If this property is set, the hub will ensure that we do not exceed a certain number of workers. 
+	/// </summary>
+	public uint? MaxParallelism { get; set; } = null;
 }

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
Allow users not to exceed the maximum parallelism when creating a new hub by allow to set a max parallel option. When the option is set, rather than DOS attacking the thread pool of dotnet, the hub will use a semaphore to throttle the number of threads used. 